### PR TITLE
yazi: transparent font preview with light glyphs

### DIFF
--- a/modules/home-manager/yazi/default.nix
+++ b/modules/home-manager/yazi/default.nix
@@ -10,6 +10,9 @@
     {
       options.kriswill.yazi.enable = lib.mkEnableOption "yazi";
       config = lib.mkIf config.kriswill.yazi.enable {
+        # `magick` (ImageMagick 7) is required by the font previewer.
+        home.packages = [ pkgs.imagemagick ];
+
         programs.yazi = {
           enable = lib.mkDefault true;
           shellWrapperName = "y";
@@ -17,6 +20,10 @@
           plugins = {
             inherit (pkgs.yaziPlugins) git;
             faster-piper = inputs.faster-piper-yazi;
+            # Font previewer with light glyphs on a transparent background.
+            # Wired via explicit preloader + previewer rules below — yazi
+            # won't let a user plugin named `font` override the preset.
+            font-dark = ./font-dark.yazi;
           };
           initLua = ''
             require("git"):setup()
@@ -47,7 +54,30 @@
                   run = "git";
                 }
               ];
+              # Font previews are rendered by the *preloader* (it writes the
+              # cached image) and merely displayed by the previewer. Override
+              # both, else the built-in `font` preloader caches a white image
+              # first and `font-dark`'s peek short-circuits on the existing
+              # cache. Mirror the preset's two font mime rules.
+              prepend_preloaders = [
+                {
+                  mime = "font/*";
+                  run = "font-dark";
+                }
+                {
+                  mime = "application/ms-opentype";
+                  run = "font-dark";
+                }
+              ];
               prepend_previewers = [
+                {
+                  mime = "font/*";
+                  run = "font-dark";
+                }
+                {
+                  mime = "application/ms-opentype";
+                  run = "font-dark";
+                }
                 {
                   url = "*.md";
                   run = ''faster-piper -- CLICOLOR_FORCE=1 glow -w=$w -s="${config.kriswill.glow.stylePath}" "$1"'';

--- a/modules/home-manager/yazi/font-dark.yazi/main.lua
+++ b/modules/home-manager/yazi/font-dark.yazi/main.lua
@@ -1,0 +1,61 @@
+-- Override of yazi's built-in `font` previewer.
+-- Identical to the preset except: transparent background (PNG, `xc:none`)
+-- with light glyphs, so the preview blends into the terminal background.
+
+local TEXT = "ABCDEFGHIJKLM\nNOPQRSTUVWXYZ\nabcdefghijklm\nnopqrstuvwxyz\n1234567890\n!$&*()[]{}"
+
+local M = {}
+
+function M:peek(job)
+	local start, cache = os.clock(), ya.file_cache(job)
+	if not cache then
+		return
+	end
+
+	local ok, err = self:preload(job)
+	if not ok or err then
+		return ya.preview_widget(job, err)
+	end
+
+	ya.sleep(math.max(0, rt.preview.image_delay / 1000 + start - os.clock()))
+
+	local _, err = ya.image_show(cache, job.area)
+	ya.preview_widget(job, err)
+end
+
+function M:seek() end
+
+function M:preload(job)
+	local cache = ya.file_cache(job)
+	if not cache or fs.cha(cache) then
+		return true
+	end
+
+	local status, err = Command("magick"):arg({
+		"-size",
+		"800x560",
+		"-gravity",
+		"center",
+		"-font",
+		tostring(job.file.path):gsub("\\", "\\\\"),
+		"-pointsize",
+		64,
+		"xc:none",
+		"-fill",
+		"#dcd7ba",
+		"-annotate",
+		"+0+0",
+		TEXT,
+		"PNG:" .. tostring(cache),
+	}):status()
+
+	if not status then
+		return true, Err("Failed to start `magick`, error: %s", err)
+	elseif not status.success then
+		return false, Err("`magick` exited with error code: %s", status.code)
+	else
+		return true
+	end
+end
+
+return M


### PR DESCRIPTION
## What

Recolors yazi's TrueType/OpenType font previews to **light glyphs on a transparent background** (blends into the terminal) instead of the default black-on-white.

| Before | After |
|--------|-------|
| black text, white background | `#dcd7ba` glyphs, transparent (PNG alpha) |

## How

- New `font-dark` plugin (`modules/home-manager/yazi/font-dark.yazi/main.lua`) — a copy of yazi's preset `font.lua` with `xc:none` + `-fill "#dcd7ba"`, emitting PNG (JPEG has no alpha).
- Routes font files to it via **both** `prepend_preloaders` and `prepend_previewers` (mirroring the preset's `font/*` and `application/ms-opentype` mime rules).
- Adds `imagemagick` to the module's `home.packages` — the previewer shells out to `magick`.

## Why both preloader *and* previewer

Yazi's font preview is two stages sharing one per-file cache: the **preloader** renders the image and writes the cache; the **previewer** only displays it. Overriding the previewer alone left the built-in `font` preloader writing the white image first, and `font-dark`'s `peek` short-circuited on the existing cache. Overriding the preloader is what actually changes the rendered output.

## Notes

- Requires a terminal whose image protocol composites alpha (Ghostty / kitty protocol) for true transparency.
- After changing the plugin, the preview cache (`$TMPDIR/yazi-<uid>/`) must be cleared or already-viewed files keep their stale render.