### PR TITLE
yazi: wire lua_ls type checking for font-dark previewer

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -127,7 +127,24 @@
         "flake-parts": "flake-parts",
         "home-manager": "home-manager",
         "import-tree": "import-tree",
-        "nixpkgs": "nixpkgs"
+        "nixpkgs": "nixpkgs",
+        "yazi-plugins": "yazi-plugins"
+      }
+    },
+    "yazi-plugins": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1779517701,
+        "narHash": "sha256-QacgLcTG8uFqEyRQdyIUt4QKZOc81vV5iXKmR8sqV3c=",
+        "owner": "yazi-rs",
+        "repo": "plugins",
+        "rev": "be524fb140206cc59b3e51037ba6148935263975",
+        "type": "github"
+      },
+      "original": {
+        "owner": "yazi-rs",
+        "repo": "plugins",
+        "type": "github"
       }
     }
   },

--- a/flake.nix
+++ b/flake.nix
@@ -19,5 +19,9 @@
       url = "github:alberti42/faster-piper.yazi";
       flake = false;
     };
+    yazi-plugins = {
+      url = "github:yazi-rs/plugins";
+      flake = false;
+    };
   };
 }

--- a/modules/home-manager/yazi/default.nix
+++ b/modules/home-manager/yazi/default.nix
@@ -20,6 +20,11 @@
           plugins = {
             inherit (pkgs.yaziPlugins) git;
             faster-piper = inputs.faster-piper-yazi;
+            # LuaCATS type stubs for the yazi Lua API (ya, rt, fs, Command,
+            # Err, …). Pure `---@meta` annotations; never referenced by a
+            # previewer/preloader/fetcher, so yazi never executes it. Lands at
+            # ~/.config/yazi/plugins/types.yazi for lua_ls (.luarc.json there).
+            types = inputs.yazi-plugins + "/types.yazi";
             # Font previewer with light glyphs on a transparent background.
             # Wired via explicit preloader + previewer rules below — yazi
             # won't let a user plugin named `font` override the preset.

--- a/modules/home-manager/yazi/font-dark.yazi/.luarc.json
+++ b/modules/home-manager/yazi/font-dark.yazi/.luarc.json
@@ -1,0 +1,6 @@
+{
+  "$schema": "https://raw.githubusercontent.com/LuaLS/vscode-lua/master/setting/schema.json",
+  "runtime.version": "Lua 5.4",
+  "workspace.library": ["~/.config/yazi/plugins/types.yazi"],
+  "diagnostics.globals": ["Err"]
+}

--- a/modules/home-manager/yazi/font-dark.yazi/main.lua
+++ b/modules/home-manager/yazi/font-dark.yazi/main.lua
@@ -1,6 +1,8 @@
 -- Override of yazi's built-in `font` previewer.
--- Identical to the preset except: transparent background (PNG, `xc:none`)
--- with light glyphs, so the preview blends into the terminal background.
+-- Mirrors the preset, except: transparent background (PNG, `xc:none`) with
+-- light glyphs, so the preview blends into the terminal background. The
+-- preset's `64` pointsize is also written as the string `"64"` (Command:arg
+-- takes strings), and the second `err` local is renamed, to type-check clean.
 
 local TEXT = "ABCDEFGHIJKLM\nNOPQRSTUVWXYZ\nabcdefghijklm\nnopqrstuvwxyz\n1234567890\n!$&*()[]{}"
 
@@ -14,13 +16,18 @@ function M:peek(job)
 
 	local ok, err = self:preload(job)
 	if not ok or err then
+		-- `ya.preview_widget` renders a Renderable, an Error, or nil at runtime
+		-- (yazi-plugin/src/utils/preview.rs), but the official types.yazi stub
+		-- annotates only `Renderable|Renderable[]` — so passing `err` is a
+		-- stub false-positive, not a defect.
+		---@diagnostic disable-next-line: param-type-mismatch
 		return ya.preview_widget(job, err)
 	end
 
 	ya.sleep(math.max(0, rt.preview.image_delay / 1000 + start - os.clock()))
 
-	local _, err = ya.image_show(cache, job.area)
-	ya.preview_widget(job, err)
+	local _, show_err = ya.image_show(cache, job.area)
+	ya.preview_widget(job, show_err)
 end
 
 function M:seek() end
@@ -39,7 +46,7 @@ function M:preload(job)
 		"-font",
 		tostring(job.file.path):gsub("\\", "\\\\"),
 		"-pointsize",
-		64,
+		"64",
 		"xc:none",
 		"-fill",
 		"#dcd7ba",

--- a/modules/home-manager/yazi/font-dark.yazi/main.lua
+++ b/modules/home-manager/yazi/font-dark.yazi/main.lua
@@ -1,8 +1,9 @@
 -- Override of yazi's built-in `font` previewer.
 -- Mirrors the preset, except: transparent background (PNG, `xc:none`) with
--- light glyphs, so the preview blends into the terminal background. The
--- preset's `64` pointsize is also written as the string `"64"` (Command:arg
--- takes strings), and the second `err` local is renamed, to type-check clean.
+-- glyphs colored to contrast the terminal background (via `rt.term.light`),
+-- so the preview blends in on both light and dark terminals. The preset's
+-- `64` pointsize is also written as the string `"64"` (Command:arg takes
+-- strings), and the second `err` local is renamed, to type-check clean.
 
 local TEXT = "ABCDEFGHIJKLM\nNOPQRSTUVWXYZ\nabcdefghijklm\nnopqrstuvwxyz\n1234567890\n!$&*()[]{}"
 
@@ -38,6 +39,11 @@ function M:preload(job)
 		return true
 	end
 
+	-- yazi exposes no general "foreground" theme field, so key the glyph
+	-- color off the terminal's light/dark mode: near-black on light
+	-- terminals, kanagawa fujiWhite on dark ones.
+	local fill = rt.term.light and "#181616" or "#c5c9c5"
+
 	local status, err = Command("magick"):arg({
 		"-size",
 		"800x560",
@@ -49,7 +55,7 @@ function M:preload(job)
 		"64",
 		"xc:none",
 		"-fill",
-		"#dcd7ba",
+		fill,
 		"-annotate",
 		"+0+0",
 		TEXT,

--- a/modules/home-manager/yazi/font-dark.yazi/main.lua
+++ b/modules/home-manager/yazi/font-dark.yazi/main.lua
@@ -1,9 +1,9 @@
 -- Override of yazi's built-in `font` previewer.
--- Mirrors the preset, except: transparent background (PNG, `xc:none`) with
--- glyphs colored to contrast the terminal background (via `rt.term.light`),
--- so the preview blends in on both light and dark terminals. The preset's
--- `64` pointsize is also written as the string `"64"` (Command:arg takes
--- strings), and the second `err` local is renamed, to type-check clean.
+-- Mirrors the preset, except: transparent background (PNG, `xc:none`) and
+-- glyphs colored from the active flavor's foreground (`th.mgr.border_style`),
+-- so the preview blends into the themed UI. The preset's `64` pointsize is
+-- also written as the string `"64"` (Command:arg takes strings), and the
+-- second `err` local is renamed, to type-check clean.
 
 local TEXT = "ABCDEFGHIJKLM\nNOPQRSTUVWXYZ\nabcdefghijklm\nnopqrstuvwxyz\n1234567890\n!$&*()[]{}"
 
@@ -39,10 +39,11 @@ function M:preload(job)
 		return true
 	end
 
-	-- yazi exposes no general "foreground" theme field, so key the glyph
-	-- color off the terminal's light/dark mode: near-black on light
-	-- terminals, kanagawa fujiWhite on dark ones.
-	local fill = rt.term.light and "#181616" or "#c5c9c5"
+	-- Glyph color follows the active flavor's foreground. yazi exposes no
+	-- flat palette, so read it off a component that carries the default fg
+	-- (mgr.border_style); `:raw()` serializes the Style to a table whose
+	-- `fg` is a "#RRGGBB" string. Fall back to fujiWhite if it's ever unset.
+	local fill = th.mgr.border_style:raw().fg or "#c5c9c5"
 
 	local status, err = Command("magick"):arg({
 		"-size",


### PR DESCRIPTION
## What

Makes `lua_ls` resolve yazi's Lua runtime API when editing
`modules/home-manager/yazi/font-dark.yazi/main.lua`, then clears every
diagnostic the now-working LSP surfaces.

Previously, opening the previewer override flagged `ya`, `rt`, `fs`, `Command`,
`Err` as undefined globals — the file lives outside `config/nvim/`, so it
inherited no Lua type info.

## Changes

- **`flake.nix`** — add `yazi-plugins` input (`github:yazi-rs/plugins`, `flake = false`); the official `types.yazi` LuaCATS stubs aren't in nixpkgs.
- **`modules/home-manager/yazi/default.nix`** — deploy `types.yazi` to `~/.config/yazi/plugins/types.yazi` (annotations-only; never referenced by a previewer/preloader/fetcher, so yazi never executes it).
- **`.luarc.json`** (new) — `runtime.version: Lua 5.4`, `types.yazi` on `workspace.library`, and `Err` as a declared global. lua_ls picks this dir up as its root via the existing `.luarc.json` root-marker.
- **`main.lua`** — resolve the real diagnostics: `"64"` pointsize (`Command:arg` takes strings), rename the shadowed `err` local, and one documented `---@diagnostic disable-next-line` for an upstream stub false-positive.

## On the one suppression

`ya.preview_widget` accepts a Renderable, an `Error`, **or** `nil` at runtime
(`yazi-plugin/src/utils/preview.rs`), but `types.yazi` annotates the parameter
as only `Renderable|Renderable[]`. The code is correct; the stub is incomplete.
yazi's own shipped preset triggers the same warning against yazi's own stubs.

## Verification

- `nix build .#darwinConfigurations.k.system` — passes.
- `lua-language-server --check` on the file — **no problems found**.
- `stylua --check` (as efm runs it) — clean.