### PR TITLE
podman: switch machine provider libkrun→applehv, pin vfkit

### DIFF
--- a/config/containers/containers.conf
+++ b/config/containers/containers.conf
@@ -3,7 +3,12 @@
 env = []
 
 [machine]
-provider = "libkrun"
+# applehv = Apple Virtualization.framework (via the vfkit helper) — the stable,
+# default podman machine backend on Apple Silicon.
+# Previously "libkrun": nixpkgs' libkrun-efi build ships no EFI firmware, so krunkit
+# fails to boot the VM ("can't find a firmware to load"). M1 has no nested-virt, so
+# libkrun's GPU/nested features bought us nothing here anyway.
+provider = "applehv"
 
 [network]
 [secrets]

--- a/modules/home-manager/podman-desktop.nix
+++ b/modules/home-manager/podman-desktop.nix
@@ -12,6 +12,10 @@
         home.packages = [
           pkgs.podman-desktop
           pkgs.podman
+          # vfkit is the helper binary podman drives for the "applehv" machine
+          # provider (see config/containers/containers.conf). Pin it explicitly so a
+          # nixpkgs bump can't drop it off PATH and break `podman machine start`.
+          pkgs.vfkit
           pkgs.k9s
         ];
 


### PR DESCRIPTION
## Problem

A routine `nix flake update` bumped `krunkit` → 1.2.1 / `libkrun-efi` → 1.18.0. The nixpkgs `libkrun-efi` build ships its dylibs but **no EFI firmware**, so `krunkit` exits immediately with `Error: can't find a firmware to load`. With the libkrun VM monitor dying on every launch, `podman machine start` / `stop` / `reset` all fail — the machine can't boot. (The previously-running VM was killed when the new generation activated; the gvproxy log shows krunkit disconnecting and gvproxy exiting.)

## Fix

- **`config/containers/containers.conf`**: machine `provider` `libkrun` → `applehv` (Apple Virtualization.framework via the `vfkit` helper). applehv is the stable default backend on Apple Silicon and needs no external firmware. This box is an M1 Max with no nested-virt, so libkrun's GPU/`--nested` features were unused.
- **`modules/home-manager/podman-desktop.nix`**: pin `pkgs.vfkit` so a future nixpkgs bump can't drop the applehv helper off `PATH`.

## Verification

- `nix build .#darwinConfigurations.k.system` → builds clean.
- `darwin-rebuild switch` applied; effective `containers.conf` now `provider = "applehv"`, `vfkit` on PATH.
- Recreated the machine on applehv (5 CPU / 10 GiB / 100 GiB, rootful): `podman version` → client+server 5.8.2; `podman run --rm quay.io/podman/hello` → `!... Hello Podman World ...!`.
- The `PODMAN_SOCK` command that `p4c-k8s`'s `task local:up` relies on resolves correctly.