### PR TITLE
okf viz: composable sidebar filtering (grouped legend, search, neighborhood isolation, platform axis)

### DIFF
--- a/knowledge/log.md
+++ b/knowledge/log.md
@@ -2,6 +2,31 @@
 
 ## 2026-07-03
 
+- **Update** — viz filter UX, phase B (grouped legend + neighborhood
+  isolation), on top of phase A. The 14-type legend clusters into 4 groups
+  (Knowledge/System/Packages/Neovim) derived from each concept's bundle
+  directory (a new `dirOf`/`GROUP_OF_DIR` map, zero hand-authored per-type
+  taxonomy) — group headers get their own toggle-whole-cluster / alt-click-
+  solo-cluster, alongside the existing per-type controls. Selecting a
+  concept now shows a 1-hop/2-hop/off control that restricts the sidebar
+  (and the 3D scene's dimming) to its graph neighborhood, ANDed with the
+  type/search filters, sticky across concept-to-concept clicks but
+  suspended while a file/dir view is open; `?isolate=1|2` joins `hide=`/`q=`
+  in the URL. Implemented directly (the two commits are too interdependent
+  for parallel-agent authorship) but verified and reviewed through two
+  multi-agent workflow passes — one per commit, each running svelte-check +
+  a real headless-Chrome interaction drive in parallel with a 3-dimension
+  adversarial code review. Both passes found genuine issues before commit:
+  phase's first pass caught a dormant non-deterministic bug (a type's
+  legend group depended on node array order) and an undetected regression
+  risk in the group-toggle logic; the second caught a misleading sidebar
+  count during sticky-but-inactive isolation, a real high-severity test gap
+  (no test drove opening a file view while isolated), a duplicated
+  id-resolution derivation, and a component class name collision — all
+  fixed, with tests pinning the corrected behavior. Deferred: the platform
+  (darwin/nixos/dual) facet, collapsible legend groups, an isolation-
+  suppressed-matches note parallel to phase A's type-filter one.
+
 - **Update** — viz filter UX, phase A (quick wins). The legend gains
   all/none header links and alt-click-to-isolate (one click instead of
   N−1 toggles); the search haystack now includes frontmatter `tags` and the

--- a/knowledge/log.md
+++ b/knowledge/log.md
@@ -2,6 +2,20 @@
 
 ## 2026-07-03
 
+- **Update** — viz filter UX, phase A (quick wins). The legend gains
+  all/none header links and alt-click-to-isolate (one click instead of
+  N−1 toggles); the search haystack now includes frontmatter `tags` and the
+  placeholder says what it filters (title/type/tag — it always also matched
+  id and description); the counts line goes live ("42 of 131 concepts")
+  whenever a filter is active; search hits suppressed by a hidden type
+  surface as a clickable "+n hidden by type filters" note instead of
+  silently vanishing; and the whole lens (hidden types + query) now rides
+  the URL hash behind the selection (`c/<id>?hide=A,B&q=…`) — filter-only
+  changes amend the history entry via `replaceState`, selection changes
+  still push, so Back walks selections and shared links reproduce the view.
+  Phase B (grouped legend matching the bundle topology, neighborhood
+  isolation) is planned separately.
+
 - **Update** — `okf viz` links commit-hash citations to GitHub. `` `abc1234` ``
   code spans (the profile's citation convention) in concept bodies and
   embedded markdown now render as outbound `github.com/…/commit/<full-oid>`

--- a/knowledge/log.md
+++ b/knowledge/log.md
@@ -2,6 +2,31 @@
 
 ## 2026-07-03
 
+- **Update** — viz filter UX, phase C (platform axis), on top of phases A/B.
+  A segmented `all | darwin | nixos` control below the legend filters the
+  graph by which OS a concept applies to; `darwin` shows darwin + dual +
+  neutral concepts (hiding nixos-only), `nixos` the mirror, `all` everything —
+  composed via AND with the type/search/neighborhood filters, riding the URL
+  as `?os=darwin|nixos`. The platform of each concept is **derived from repo
+  structure**, not hand-authored: modules by `type` (Darwin/NixOS/Dual/
+  Flake-parts), hosts by host-id (nebula = nixos, rest = darwin), nvim = both,
+  knowledge = neutral, and packages by parsing the darwin/linux
+  `lib.optionalAttrs` guards in `modules/packages.nix` (a brace-depth,
+  depth-aware scan baked into the graph at build time by `viz.ts`). Known
+  limitation: `noctalia-config`/`helium-config` build unconditionally
+  (file-copy scripts) so they classify `both` despite being Linux-desktop
+  tools — the direct consequence of deriving from build structure. Verified
+  and reviewed through a multi-agent workflow (svelte-check + a headless-Chrome
+  drive incl. a 3D-scene-dim probe, in parallel with a 3-dimension adversarial
+  review); the review found no correctness bugs — the four confirmed
+  low-severity findings (a stale hash header comment, an unexercised parser
+  edge, a not-quite-pinned replaceState test, and `.seg`/`.hint` CSS
+  duplicated across the two segmented controls) were all fixed: the parser is
+  now depth-aware against nested `callPackage` args, and the shared control
+  primitives were hoisted into the global stylesheet. Still deferred: a
+  `platform:` frontmatter field, knowledge-doc platform lean, and a
+  platform-suppressed-matches note.
+
 - **Update** — viz filter UX, phase B (grouped legend + neighborhood
   isolation), on top of phase A. The 14-type legend clusters into 4 groups
   (Knowledge/System/Packages/Neovim) derived from each concept's bundle

--- a/scripts/okf/viz-app/App.svelte
+++ b/scripts/okf/viz-app/App.svelte
@@ -29,7 +29,7 @@
     const h = encodeViewHash(view);
     if (h === currentState) return;
     currentState = h;
-    viz.setFilters(view.filters.hidden, view.filters.q);
+    viz.setFilters(view.filters.hidden, view.filters.q, view.filters.isolate);
     const sel = view.sel;
     if (sel.kind === "concept") viz.selectConcept(sel.id, true);
     else if (sel.kind === "file") viz.selectFile(sel.path);
@@ -38,7 +38,7 @@
   }
 
   $effect(() => {
-    const h = encodeViewHash({ sel: viz.sel, filters: { hidden: [...viz.hidden], q: viz.query } });
+    const h = encodeViewHash({ sel: viz.sel, filters: { hidden: [...viz.hidden], q: viz.query, isolate: viz.isolateDepth } });
     if (currentState === h) return;
     const selChanged = currentState == null || selPart(h) !== selPart(currentState);
     currentState = h;

--- a/scripts/okf/viz-app/App.svelte
+++ b/scripts/okf/viz-app/App.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-  import { decodeHash, encodeHash } from "./hash";
+  import { decodeViewHash, encodeViewHash } from "./hash";
   import { installPerf, mark, summary } from "./perf";
   import type { CreateScene, SceneApi } from "./scene";
   import Sidebar from "./Sidebar.svelte";
@@ -13,18 +13,24 @@
   }
   const { viz, createScene }: Props = $props();
 
-  /* --- URL state (hash) — selections survive reload and back/forward ------ */
+  /* --- URL state (hash) — selection + filters survive reload/back/forward - */
   let currentState: string | null = null;
+  const selPart = (h: string) => h.split("?", 1)[0]!;
 
   function applyHash() {
-    // decodeHash owns the (single) decode of the raw hash. currentState always
-    // holds the canonical encodeHash form, so an encoded deep link compares
-    // equal to what the write-effect stores: the URL is applied, never
-    // rewritten (a rewrite pushes a history entry per navigation — Back trap).
-    const sel = decodeHash(location.hash.slice(1), viz.model);
-    const h = encodeHash(sel);
+    // decodeViewHash owns the (single) decode of the raw hash. currentState
+    // always holds the canonical encodeViewHash form, so an encoded deep link
+    // compares equal to what the write-effect stores: the URL is applied,
+    // never rewritten (a rewrite pushes a history entry per navigation —
+    // Back trap). A hash without filter params clears the filters: every
+    // in-app link is click-intercepted, so a bare hash only arrives via
+    // deep link, hand edit, or Back to an unfiltered entry.
+    const view = decodeViewHash(location.hash.slice(1), viz.model);
+    const h = encodeViewHash(view);
     if (h === currentState) return;
     currentState = h;
+    viz.setFilters(view.filters.hidden, view.filters.q);
+    const sel = view.sel;
     if (sel.kind === "concept") viz.selectConcept(sel.id, true);
     else if (sel.kind === "file") viz.selectFile(sel.path);
     else if (sel.kind === "dir") viz.selectDir(sel.path);
@@ -32,10 +38,13 @@
   }
 
   $effect(() => {
-    const h = encodeHash(viz.sel);
+    const h = encodeViewHash({ sel: viz.sel, filters: { hidden: [...viz.hidden], q: viz.query } });
     if (currentState === h) return;
+    const selChanged = currentState == null || selPart(h) !== selPart(currentState);
     currentState = h;
-    if (location.hash.slice(1) !== h) {
+    if (location.hash.slice(1) === h) return;
+    if (selChanged) {
+      // Selection navigations get history entries (Back walks selections).
       if (h) location.hash = h;
       else {
         try {
@@ -43,6 +52,14 @@
         } catch {
           location.hash = "";
         }
+      }
+    } else {
+      // Filter-only change: keep the URL shareable without one history entry
+      // per keystroke/toggle — the current entry is amended in place.
+      try {
+        history.replaceState(null, "", h ? "#" + h : location.pathname + location.search);
+      } catch {
+        location.hash = h;
       }
     }
   });

--- a/scripts/okf/viz-app/App.svelte
+++ b/scripts/okf/viz-app/App.svelte
@@ -29,7 +29,7 @@
     const h = encodeViewHash(view);
     if (h === currentState) return;
     currentState = h;
-    viz.setFilters(view.filters.hidden, view.filters.q, view.filters.isolate);
+    viz.setFilters(view.filters.hidden, view.filters.q, view.filters.isolate, view.filters.platform);
     const sel = view.sel;
     if (sel.kind === "concept") viz.selectConcept(sel.id, true);
     else if (sel.kind === "file") viz.selectFile(sel.path);
@@ -38,7 +38,10 @@
   }
 
   $effect(() => {
-    const h = encodeViewHash({ sel: viz.sel, filters: { hidden: [...viz.hidden], q: viz.query, isolate: viz.isolateDepth } });
+    const h = encodeViewHash({
+      sel: viz.sel,
+      filters: { hidden: [...viz.hidden], q: viz.query, isolate: viz.isolateDepth, platform: viz.platform },
+    });
     if (currentState === h) return;
     const selChanged = currentState == null || selPart(h) !== selPart(currentState);
     currentState = h;

--- a/scripts/okf/viz-app/ConceptList.svelte
+++ b/scripts/okf/viz-app/ConceptList.svelte
@@ -28,6 +28,12 @@
       }}><span class="dot" style="background:{viz.colorOf(n.type)}"></span>{n.title}</a
     >
   {/each}
+  {#if viz.hiddenMatchCount > 0}
+    <button class="hidden-note" onclick={() => viz.showAllTypes()}>
+      +{viz.hiddenMatchCount}
+      {viz.hiddenMatchCount === 1 ? "match" : "matches"} hidden by type filters — show all
+    </button>
+  {/if}
 </nav>
 
 <style>
@@ -66,5 +72,22 @@
     border-radius: 50%;
     margin-right: 7px;
     vertical-align: 1px;
+  }
+  .hidden-note {
+    display: block;
+    width: 100%;
+    padding: 4px;
+    font: inherit;
+    font-size: 12px;
+    text-align: left;
+    color: var(--ink-muted);
+    background: none;
+    border: none;
+    border-radius: 5px;
+    cursor: pointer;
+  }
+  .hidden-note:hover {
+    background: var(--page);
+    color: var(--ink-1);
   }
 </style>

--- a/scripts/okf/viz-app/ConceptList.svelte
+++ b/scripts/okf/viz-app/ConceptList.svelte
@@ -4,9 +4,7 @@
 
   const { viz }: { viz: VizState } = $props();
 
-  // The focused concept: the selected one, or the referrer while a file view
-  // is open (matches the scene's emphasis).
-  const focusedId = $derived((viz.selectedConcept ?? viz.backConcept)?.id ?? null);
+  const focusedId = $derived(viz.focusedConcept?.id ?? null);
 
   let nav: HTMLElement | null = $state(null);
   $effect(() => {

--- a/scripts/okf/viz-app/IsolateControl.svelte
+++ b/scripts/okf/viz-app/IsolateControl.svelte
@@ -1,0 +1,64 @@
+<script lang="ts">
+  import type { VizState } from "./state.svelte";
+
+  const { viz }: { viz: VizState } = $props();
+</script>
+
+{#if viz.selectedConcept}
+  <div id="isolate">
+    <span class="hint">neighbors</span>
+    <button
+      class="seg"
+      class:active={viz.isolateDepth === 1}
+      onclick={() => viz.setIsolate(viz.isolateDepth === 1 ? 0 : 1)}
+    >
+      1-hop
+    </button>
+    <button
+      class="seg"
+      class:active={viz.isolateDepth === 2}
+      onclick={() => viz.setIsolate(viz.isolateDepth === 2 ? 0 : 2)}
+    >
+      2-hop
+    </button>
+    <button class="seg" class:active={viz.isolateDepth === 0} onclick={() => viz.setIsolate(0)}>off</button>
+  </div>
+{/if}
+
+<style>
+  #isolate {
+    display: flex;
+    align-items: center;
+    gap: 5px;
+    padding: 6px 4px;
+    margin-bottom: 6px;
+    border-top: 1px solid var(--grid);
+    border-bottom: 1px solid var(--grid);
+  }
+  #isolate .hint {
+    margin-right: auto;
+    color: var(--ink-muted);
+    font-size: 11px;
+    text-transform: uppercase;
+    letter-spacing: 0.05em;
+  }
+  #isolate .seg {
+    padding: 2px 6px;
+    font: inherit;
+    font-size: 12px;
+    color: var(--ink-muted);
+    background: none;
+    border: 1px solid transparent;
+    border-radius: 5px;
+    cursor: pointer;
+  }
+  #isolate .seg:hover {
+    color: var(--ink-1);
+  }
+  #isolate .seg.active {
+    color: var(--ink-1);
+    border-color: var(--grid);
+    background: var(--page);
+    font-weight: 600;
+  }
+</style>

--- a/scripts/okf/viz-app/IsolateControl.svelte
+++ b/scripts/okf/viz-app/IsolateControl.svelte
@@ -26,6 +26,7 @@
 {/if}
 
 <style>
+  /* .hint / .seg are global primitives (viz.ts) shared with the other controls. */
   #isolate {
     display: flex;
     align-items: center;
@@ -34,31 +35,5 @@
     margin-bottom: 6px;
     border-top: 1px solid var(--grid);
     border-bottom: 1px solid var(--grid);
-  }
-  #isolate .hint {
-    margin-right: auto;
-    color: var(--ink-muted);
-    font-size: 11px;
-    text-transform: uppercase;
-    letter-spacing: 0.05em;
-  }
-  #isolate .seg {
-    padding: 2px 6px;
-    font: inherit;
-    font-size: 12px;
-    color: var(--ink-muted);
-    background: none;
-    border: 1px solid transparent;
-    border-radius: 5px;
-    cursor: pointer;
-  }
-  #isolate .seg:hover {
-    color: var(--ink-1);
-  }
-  #isolate .seg.active {
-    color: var(--ink-1);
-    border-color: var(--grid);
-    background: var(--page);
-    font-weight: 600;
   }
 </style>

--- a/scripts/okf/viz-app/Legend.svelte
+++ b/scripts/okf/viz-app/Legend.svelte
@@ -59,13 +59,7 @@
     gap: 5px;
     padding: 0 4px 3px;
   }
-  .leg-head .hint {
-    margin-right: auto;
-    color: var(--ink-muted);
-    font-size: 11px;
-    text-transform: uppercase;
-    letter-spacing: 0.05em;
-  }
+  /* .hint is a global primitive (viz.ts), shared with the sidebar controls. */
   .leg-head .sep {
     color: var(--ink-muted);
     font-size: 12px;

--- a/scripts/okf/viz-app/Legend.svelte
+++ b/scripts/okf/viz-app/Legend.svelte
@@ -4,6 +4,14 @@
   const { viz }: { viz: VizState } = $props();
 
   const toggle = (t: string, alt: boolean) => (alt ? viz.soloType(t) : viz.toggleType(t));
+  const toggleGroup = (g: string, alt: boolean) => (alt ? viz.soloGroup(g) : viz.toggleGroup(g));
+  const onActivateKey = (fn: (alt: boolean) => void) => (e: KeyboardEvent) => {
+    if (e.key === "Enter" || e.key === " ") {
+      e.preventDefault();
+      fn(e.altKey);
+    }
+  };
+  const groupOff = (g: string) => viz.model.groupTypes[g]!.every((t) => viz.hidden.has(t));
 </script>
 
 <div id="legend">
@@ -13,23 +21,33 @@
     <span class="sep">·</span>
     <button class="lnk" onclick={() => viz.hideAllTypes()}>none</button>
   </div>
-  {#each viz.model.allTypes as t (t)}
-    <div
-      class="leg"
-      class:off={viz.hidden.has(t)}
-      role="button"
-      tabindex="0"
-      title="click toggles · alt-click isolates"
-      onclick={(e) => toggle(t, e.altKey)}
-      onkeydown={(e) => {
-        if (e.key === "Enter" || e.key === " ") {
-          e.preventDefault();
-          toggle(t, e.altKey);
-        }
-      }}
-    >
-      <span class="dot" style="background:{viz.colorOf(t)}"></span>{t}
-      <span class="n">{viz.model.typeCounts[t]}</span>
+  {#each viz.model.groupOrder as g (g)}
+    <div class="grp">
+      <div
+        class="leg-group"
+        class:off={groupOff(g)}
+        role="button"
+        tabindex="0"
+        title="click toggles the group · alt-click isolates it"
+        onclick={(e) => toggleGroup(g, e.altKey)}
+        onkeydown={onActivateKey((alt) => toggleGroup(g, alt))}
+      >
+        {g}
+      </div>
+      {#each viz.model.groupTypes[g] as t (t)}
+        <div
+          class="leg"
+          class:off={viz.hidden.has(t)}
+          role="button"
+          tabindex="0"
+          title="click toggles · alt-click isolates"
+          onclick={(e) => toggle(t, e.altKey)}
+          onkeydown={onActivateKey((alt) => toggle(t, alt))}
+        >
+          <span class="dot" style="background:{viz.colorOf(t)}"></span>{t}
+          <span class="n">{viz.model.typeCounts[t]}</span>
+        </div>
+      {/each}
     </div>
   {/each}
 </div>
@@ -65,17 +83,39 @@
     color: var(--ink-1);
     text-decoration: underline;
   }
+  .grp {
+    margin-bottom: 4px;
+  }
+  .leg-group {
+    padding: 5px 4px 2px;
+    font-size: 11px;
+    font-weight: 600;
+    text-transform: uppercase;
+    letter-spacing: 0.04em;
+    color: var(--ink-muted);
+    border-radius: 5px;
+    cursor: pointer;
+    user-select: none;
+  }
+  .leg-group:hover {
+    background: var(--page);
+    color: var(--ink-1);
+  }
+  .leg-group.off {
+    opacity: 0.35;
+  }
   .leg {
     display: flex;
     align-items: center;
     gap: 8px;
-    padding: 3px 4px;
+    padding: 3px 4px 3px 10px;
     border-radius: 5px;
     cursor: pointer;
     user-select: none;
   }
   .leg:hover {
     background: var(--page);
+    color: var(--ink-1);
   }
   .leg.off {
     opacity: 0.35;

--- a/scripts/okf/viz-app/Legend.svelte
+++ b/scripts/okf/viz-app/Legend.svelte
@@ -3,21 +3,28 @@
 
   const { viz }: { viz: VizState } = $props();
 
-  const toggle = (t: string) => viz.toggleType(t);
+  const toggle = (t: string, alt: boolean) => (alt ? viz.soloType(t) : viz.toggleType(t));
 </script>
 
 <div id="legend">
+  <div class="leg-head">
+    <span class="hint">types</span>
+    <button class="lnk" onclick={() => viz.showAllTypes()}>all</button>
+    <span class="sep">·</span>
+    <button class="lnk" onclick={() => viz.hideAllTypes()}>none</button>
+  </div>
   {#each viz.model.allTypes as t (t)}
     <div
       class="leg"
       class:off={viz.hidden.has(t)}
       role="button"
       tabindex="0"
-      onclick={() => toggle(t)}
+      title="click toggles · alt-click isolates"
+      onclick={(e) => toggle(t, e.altKey)}
       onkeydown={(e) => {
         if (e.key === "Enter" || e.key === " ") {
           e.preventDefault();
-          toggle(t);
+          toggle(t, e.altKey);
         }
       }}
     >
@@ -28,6 +35,36 @@
 </div>
 
 <style>
+  .leg-head {
+    display: flex;
+    align-items: center;
+    gap: 5px;
+    padding: 0 4px 3px;
+  }
+  .leg-head .hint {
+    margin-right: auto;
+    color: var(--ink-muted);
+    font-size: 11px;
+    text-transform: uppercase;
+    letter-spacing: 0.05em;
+  }
+  .leg-head .sep {
+    color: var(--ink-muted);
+    font-size: 12px;
+  }
+  .leg-head .lnk {
+    padding: 0;
+    font: inherit;
+    font-size: 12px;
+    color: var(--ink-muted);
+    background: none;
+    border: none;
+    cursor: pointer;
+  }
+  .leg-head .lnk:hover {
+    color: var(--ink-1);
+    text-decoration: underline;
+  }
   .leg {
     display: flex;
     align-items: center;

--- a/scripts/okf/viz-app/PlatformControl.svelte
+++ b/scripts/okf/viz-app/PlatformControl.svelte
@@ -1,0 +1,24 @@
+<script lang="ts">
+  import type { VizState } from "./state.svelte";
+
+  const { viz }: { viz: VizState } = $props();
+</script>
+
+<div id="platform">
+  <span class="hint">platform</span>
+  <button class="seg" class:active={viz.platform === "all"} onclick={() => viz.setPlatform("all")}>all</button>
+  <button class="seg" class:active={viz.platform === "darwin"} onclick={() => viz.setPlatform("darwin")}>darwin</button>
+  <button class="seg" class:active={viz.platform === "nixos"} onclick={() => viz.setPlatform("nixos")}>nixos</button>
+</div>
+
+<style>
+  /* .hint / .seg are global primitives (viz.ts) shared with the other controls. */
+  #platform {
+    display: flex;
+    align-items: center;
+    gap: 5px;
+    padding: 6px 4px;
+    margin-bottom: 6px;
+    border-top: 1px solid var(--grid);
+  }
+</style>

--- a/scripts/okf/viz-app/Search.svelte
+++ b/scripts/okf/viz-app/Search.svelte
@@ -4,7 +4,13 @@
   const { viz }: { viz: VizState } = $props();
 </script>
 
-<input id="q" type="search" placeholder="Search concepts…" aria-label="Search concepts" bind:value={viz.query} />
+<input
+  id="q"
+  type="search"
+  placeholder="Filter by title, type, tag…"
+  aria-label="Filter concepts by title, type, or tag"
+  bind:value={viz.query}
+/>
 
 <style>
   #q {

--- a/scripts/okf/viz-app/Sidebar.svelte
+++ b/scripts/okf/viz-app/Sidebar.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
   import ConceptList from "./ConceptList.svelte";
+  import IsolateControl from "./IsolateControl.svelte";
   import Legend from "./Legend.svelte";
   import Search from "./Search.svelte";
   import type { VizState } from "./state.svelte";
@@ -12,7 +13,7 @@
   <div class="scroll">
     <h1>knowledge/ bundle</h1>
     <div class="sub" id="counts">
-      {#if viz.hidden.size > 0 || viz.query.trim()}
+      {#if viz.hidden.size > 0 || viz.query.trim() || viz.neighborIds}
         {viz.visibleSorted.length} of {viz.model.nodes.length} concepts · {viz.model.edges.length} links
       {:else}
         {viz.model.nodes.length} concepts · {viz.model.edges.length} links
@@ -20,6 +21,7 @@
     </div>
     <Search {viz} />
     <Legend {viz} />
+    <IsolateControl {viz} />
     <ConceptList {viz} />
   </div>
   <ThemeSlider {viz} />

--- a/scripts/okf/viz-app/Sidebar.svelte
+++ b/scripts/okf/viz-app/Sidebar.svelte
@@ -11,7 +11,13 @@
 <aside id="side">
   <div class="scroll">
     <h1>knowledge/ bundle</h1>
-    <div class="sub" id="counts">{viz.model.nodes.length} concepts · {viz.model.edges.length} links</div>
+    <div class="sub" id="counts">
+      {#if viz.hidden.size > 0 || viz.query.trim()}
+        {viz.visibleSorted.length} of {viz.model.nodes.length} concepts · {viz.model.edges.length} links
+      {:else}
+        {viz.model.nodes.length} concepts · {viz.model.edges.length} links
+      {/if}
+    </div>
     <Search {viz} />
     <Legend {viz} />
     <ConceptList {viz} />

--- a/scripts/okf/viz-app/Sidebar.svelte
+++ b/scripts/okf/viz-app/Sidebar.svelte
@@ -2,6 +2,7 @@
   import ConceptList from "./ConceptList.svelte";
   import IsolateControl from "./IsolateControl.svelte";
   import Legend from "./Legend.svelte";
+  import PlatformControl from "./PlatformControl.svelte";
   import Search from "./Search.svelte";
   import type { VizState } from "./state.svelte";
   import ThemeSlider from "./ThemeSlider.svelte";
@@ -13,7 +14,7 @@
   <div class="scroll">
     <h1>knowledge/ bundle</h1>
     <div class="sub" id="counts">
-      {#if viz.hidden.size > 0 || viz.query.trim() || viz.neighborIds}
+      {#if viz.hidden.size > 0 || viz.query.trim() || viz.neighborIds || viz.platform !== "all"}
         {viz.visibleSorted.length} of {viz.model.nodes.length} concepts · {viz.model.edges.length} links
       {:else}
         {viz.model.nodes.length} concepts · {viz.model.edges.length} links
@@ -21,6 +22,7 @@
     </div>
     <Search {viz} />
     <Legend {viz} />
+    <PlatformControl {viz} />
     <IsolateControl {viz} />
     <ConceptList {viz} />
   </div>

--- a/scripts/okf/viz-app/Stage.svelte
+++ b/scripts/okf/viz-app/Stage.svelte
@@ -64,6 +64,7 @@
     void viz.hidden.size;
     void viz.isolateDepth;
     void viz.sel;
+    void viz.platform;
     scene?.setDim((i) => !viz.visible(viz.model.nodes[i]!));
   });
 

--- a/scripts/okf/viz-app/Stage.svelte
+++ b/scripts/okf/viz-app/Stage.svelte
@@ -62,6 +62,8 @@
   $effect(() => {
     void viz.query;
     void viz.hidden.size;
+    void viz.isolateDepth;
+    void viz.sel;
     scene?.setDim((i) => !viz.visible(viz.model.nodes[i]!));
   });
 

--- a/scripts/okf/viz-app/app.test.ts
+++ b/scripts/okf/viz-app/app.test.ts
@@ -86,3 +86,45 @@ describe("App hash handling", () => {
     expect(viz.sel).toEqual({ kind: "concept", id: "nvim/architecture" });
   });
 });
+
+describe("App filter persistence", () => {
+  test("filter changes land in the URL without touching the selection part", () => {
+    const viz = createVizState(model());
+    mountApp(viz);
+    viz.selectConcept("nvim/architecture");
+    flushSync();
+    viz.toggleType("Reference");
+    viz.query = "arch";
+    flushSync();
+    expect(location.hash).toBe("#c/nvim/architecture?hide=Reference&q=arch");
+    viz.setFilters([], "");
+    flushSync();
+    expect(location.hash).toBe("#c/nvim/architecture");
+  });
+
+  test("a deep link with filters applies them on mount", () => {
+    location.hash = "#c/nvim/architecture?hide=Reference&q=arch";
+    const viz = createVizState(model());
+    mountApp(viz);
+    expect(viz.sel).toEqual({ kind: "concept", id: "nvim/architecture" });
+    expect([...viz.hidden]).toEqual(["Reference"]);
+    expect(viz.query).toBe("arch");
+    expect(location.hash).toBe("#c/nvim/architecture?hide=Reference&q=arch"); // applied, never rewritten
+  });
+
+  test("selection navigation keeps active filters; Back to a bare hash clears them", () => {
+    const viz = createVizState(model());
+    mountApp(viz);
+    viz.toggleType("Reference");
+    flushSync();
+    expect(location.hash).toBe("#?hide=Reference");
+    viz.selectConcept("nvim/architecture");
+    flushSync();
+    expect(location.hash).toBe("#c/nvim/architecture?hide=Reference");
+    location.hash = "#c/nvim/architecture"; // simulate Back to an unfiltered entry
+    window.dispatchEvent(new Event("hashchange"));
+    flushSync();
+    expect(viz.hidden.size).toBe(0);
+    expect(viz.sel).toEqual({ kind: "concept", id: "nvim/architecture" });
+  });
+});

--- a/scripts/okf/viz-app/app.test.ts
+++ b/scripts/okf/viz-app/app.test.ts
@@ -2,7 +2,7 @@
 // decodeHash raw (decoded exactly once), and malformed hashes must not throw
 // during mount — pre-decoding in App used to crash component setup whenever a
 // once-decoded hash still contained a literal '%'.
-import { afterEach, describe, expect, test } from "bun:test";
+import { afterEach, describe, expect, spyOn, test } from "bun:test";
 import { flushSync, mount, unmount } from "svelte";
 import App from "./App.svelte";
 import { buildModel } from "./data";
@@ -100,6 +100,9 @@ describe("App filter persistence", () => {
     viz.setIsolate(1);
     flushSync();
     expect(location.hash).toBe("#c/nvim/architecture?hide=Reference&q=arch&isolate=1");
+    viz.setPlatform("darwin");
+    flushSync();
+    expect(location.hash).toBe("#c/nvim/architecture?hide=Reference&q=arch&isolate=1&os=darwin");
     viz.setFilters([], "");
     flushSync();
     expect(location.hash).toBe("#c/nvim/architecture");
@@ -133,6 +136,37 @@ describe("App filter persistence", () => {
     expect(viz.query).toBe("arch");
     expect(viz.isolateDepth).toBe(0);
     expect(location.hash).toBe("#f/docs/50%25.md?hide=Reference&q=arch"); // applied, never rewritten
+  });
+
+  test("a deep link with os= applies the platform lens on mount (any selection kind)", () => {
+    location.hash = "#c/nvim/architecture?os=nixos";
+    const viz = createVizState(model());
+    mountApp(viz);
+    expect(viz.sel).toEqual({ kind: "concept", id: "nvim/architecture" });
+    expect(viz.platform).toBe("nixos");
+    expect(location.hash).toBe("#c/nvim/architecture?os=nixos"); // applied, never rewritten
+  });
+
+  test("a platform-only change amends the URL in place (replaceState, no selection churn)", () => {
+    const viz = createVizState(model());
+    mountApp(viz);
+    viz.selectConcept("nvim/architecture");
+    flushSync();
+    // Spy AFTER the selection settles so we observe only the filter-only write.
+    const replace = spyOn(history, "replaceState");
+    const push = spyOn(history, "pushState");
+    viz.setPlatform("darwin");
+    flushSync();
+    expect(location.hash).toBe("#c/nvim/architecture?os=darwin");
+    // The load-bearing guarantee: a filter-only change amends the current entry
+    // (replaceState) rather than pushing a new one (the documented Back trap).
+    expect(replace).toHaveBeenCalledTimes(1);
+    expect(push).not.toHaveBeenCalled();
+    replace.mockRestore();
+    push.mockRestore();
+    viz.setPlatform("all");
+    flushSync();
+    expect(location.hash).toBe("#c/nvim/architecture");
   });
 
   test("selection navigation keeps active filters; Back to a bare hash clears them", () => {

--- a/scripts/okf/viz-app/app.test.ts
+++ b/scripts/okf/viz-app/app.test.ts
@@ -97,6 +97,9 @@ describe("App filter persistence", () => {
     viz.query = "arch";
     flushSync();
     expect(location.hash).toBe("#c/nvim/architecture?hide=Reference&q=arch");
+    viz.setIsolate(1);
+    flushSync();
+    expect(location.hash).toBe("#c/nvim/architecture?hide=Reference&q=arch&isolate=1");
     viz.setFilters([], "");
     flushSync();
     expect(location.hash).toBe("#c/nvim/architecture");
@@ -112,6 +115,26 @@ describe("App filter persistence", () => {
     expect(location.hash).toBe("#c/nvim/architecture?hide=Reference&q=arch"); // applied, never rewritten
   });
 
+  test("a deep link with an isolate param applies it on mount", () => {
+    location.hash = "#c/nvim/architecture?hide=Reference&q=arch&isolate=1";
+    const viz = createVizState(model());
+    mountApp(viz);
+    expect(viz.sel).toEqual({ kind: "concept", id: "nvim/architecture" });
+    expect(viz.isolateDepth).toBe(1);
+    expect(location.hash).toBe("#c/nvim/architecture?hide=Reference&q=arch&isolate=1"); // applied, never rewritten
+  });
+
+  test("a deep link combining a file selection with hide=/q= still applies both (isolate stays 0, not a concept)", () => {
+    location.hash = "#f/docs/50%25.md?hide=Reference&q=arch";
+    const viz = createVizState(model());
+    mountApp(viz);
+    expect(viz.sel).toEqual({ kind: "file", path: "docs/50%.md" });
+    expect([...viz.hidden]).toEqual(["Reference"]);
+    expect(viz.query).toBe("arch");
+    expect(viz.isolateDepth).toBe(0);
+    expect(location.hash).toBe("#f/docs/50%25.md?hide=Reference&q=arch"); // applied, never rewritten
+  });
+
   test("selection navigation keeps active filters; Back to a bare hash clears them", () => {
     const viz = createVizState(model());
     mountApp(viz);
@@ -121,10 +144,14 @@ describe("App filter persistence", () => {
     viz.selectConcept("nvim/architecture");
     flushSync();
     expect(location.hash).toBe("#c/nvim/architecture?hide=Reference");
+    viz.setIsolate(2);
+    flushSync();
+    expect(location.hash).toBe("#c/nvim/architecture?hide=Reference&isolate=2");
     location.hash = "#c/nvim/architecture"; // simulate Back to an unfiltered entry
     window.dispatchEvent(new Event("hashchange"));
     flushSync();
     expect(viz.hidden.size).toBe(0);
+    expect(viz.isolateDepth).toBe(0);
     expect(viz.sel).toEqual({ kind: "concept", id: "nvim/architecture" });
   });
 });

--- a/scripts/okf/viz-app/components.test.ts
+++ b/scripts/okf/viz-app/components.test.ts
@@ -60,6 +60,33 @@ describe("Legend", () => {
     expect(document.querySelector(".leg")!.classList.contains("off")).toBe(true);
     expect(state.hidden.has("Pattern")).toBe(true);
   });
+
+  test("all / none header buttons flip every type at once", () => {
+    const state = createVizState(model());
+    mountC(Legend, { viz: state });
+    const [all, none] = [...document.querySelectorAll(".leg-head .lnk")] as HTMLElement[];
+    expect(all!.textContent).toBe("all");
+    none!.click();
+    flushSync();
+    expect(state.hidden.size).toBe(2);
+    expect(document.querySelectorAll(".leg.off")).toHaveLength(2);
+    all!.click();
+    flushSync();
+    expect(state.hidden.size).toBe(0);
+  });
+
+  test("alt-click solos a type; alt-click again restores", () => {
+    const state = createVizState(model());
+    mountC(Legend, { viz: state });
+    const pattern = document.querySelector(".leg") as HTMLElement;
+    pattern.dispatchEvent(new MouseEvent("click", { altKey: true, bubbles: true }));
+    flushSync();
+    expect(state.hidden.has("Decision")).toBe(true);
+    expect(state.hidden.has("Pattern")).toBe(false);
+    pattern.dispatchEvent(new MouseEvent("click", { altKey: true, bubbles: true }));
+    flushSync();
+    expect(state.hidden.size).toBe(0);
+  });
 });
 
 describe("ConceptList", () => {
@@ -74,6 +101,22 @@ describe("ConceptList", () => {
     (document.querySelector("#list a") as HTMLElement).click();
     flushSync();
     expect(state.sel).toEqual({ kind: "concept", id: "b" });
+  });
+
+  test("search hits swallowed by a hidden type surface as a note; click restores", () => {
+    const state = createVizState(model());
+    mountC(ConceptList, { viz: state });
+    expect(document.querySelector(".hidden-note")).toBeNull();
+    state.toggleType("Pattern");
+    state.query = "beta";
+    flushSync();
+    expect(document.querySelectorAll("#list a")).toHaveLength(0);
+    const note = document.querySelector(".hidden-note") as HTMLElement;
+    expect(note.textContent?.replace(/\s+/g, " ")).toContain("+1 match hidden by type filters");
+    note.click();
+    flushSync();
+    expect(state.hidden.size).toBe(0);
+    expect([...document.querySelectorAll("#list a")].map((a) => a.textContent)).toEqual(["Beta"]);
   });
 
   test("focused concept is marked, also while its file view is open", () => {

--- a/scripts/okf/viz-app/components.test.ts
+++ b/scripts/okf/viz-app/components.test.ts
@@ -7,6 +7,7 @@ import { buildModel } from "./data";
 import DetailPanel from "./DetailPanel.svelte";
 import IsolateControl from "./IsolateControl.svelte";
 import Legend from "./Legend.svelte";
+import PlatformControl from "./PlatformControl.svelte";
 import Search from "./Search.svelte";
 import { createVizState } from "./state.svelte";
 import { node } from "./test-helpers";
@@ -249,6 +250,40 @@ describe("IsolateControl", () => {
     twoHop!.click(); // clicking the active 2-hop button again turns it off
     flushSync();
     expect(state.isolateDepth).toBe(0);
+  });
+});
+
+describe("PlatformControl", () => {
+  test("renders all/darwin/nixos segments; active tracks viz.platform; clicks set it", () => {
+    const state = createVizState(model());
+    mountC(PlatformControl, { viz: state });
+    const [all, darwin, nixos] = [...document.querySelectorAll("#platform .seg")] as HTMLElement[];
+    expect([all!.textContent?.trim(), darwin!.textContent?.trim(), nixos!.textContent?.trim()]).toEqual([
+      "all",
+      "darwin",
+      "nixos",
+    ]);
+    expect(all!.classList.contains("active")).toBe(true); // defaults to "all"
+
+    darwin!.click();
+    flushSync();
+    expect(state.platform).toBe("darwin");
+    expect(darwin!.classList.contains("active")).toBe(true);
+    expect(all!.classList.contains("active")).toBe(false);
+
+    nixos!.click();
+    flushSync();
+    expect(state.platform).toBe("nixos");
+
+    all!.click();
+    flushSync();
+    expect(state.platform).toBe("all");
+  });
+
+  test("is always rendered, with or without a selection (unlike IsolateControl)", () => {
+    const state = createVizState(model());
+    mountC(PlatformControl, { viz: state });
+    expect(document.getElementById("platform")).not.toBeNull();
   });
 });
 

--- a/scripts/okf/viz-app/components.test.ts
+++ b/scripts/okf/viz-app/components.test.ts
@@ -5,6 +5,7 @@ import { flushSync, mount, unmount } from "svelte";
 import ConceptList from "./ConceptList.svelte";
 import { buildModel } from "./data";
 import DetailPanel from "./DetailPanel.svelte";
+import IsolateControl from "./IsolateControl.svelte";
 import Legend from "./Legend.svelte";
 import Search from "./Search.svelte";
 import { createVizState } from "./state.svelte";
@@ -192,6 +193,62 @@ describe("ConceptList", () => {
     state.clearSelection();
     flushSync();
     expect(document.querySelector("#list a.selected")).toBeNull();
+  });
+});
+
+describe("IsolateControl", () => {
+  test("renders nothing when no concept is selected", () => {
+    const state = createVizState(model());
+    mountC(IsolateControl, { viz: state });
+    expect(document.getElementById("isolate")).toBeNull();
+  });
+
+  test("renders 1-hop/2-hop/off once a concept is selected; buttons drive setIsolate", () => {
+    const state = createVizState(model());
+    state.selectConcept("a");
+    mountC(IsolateControl, { viz: state });
+    const [oneHop, twoHop, off] = [...document.querySelectorAll("#isolate .seg")] as HTMLElement[];
+    expect([oneHop!.textContent?.trim(), twoHop!.textContent?.trim(), off!.textContent?.trim()]).toEqual([
+      "1-hop",
+      "2-hop",
+      "off",
+    ]);
+    expect(off!.classList.contains("active")).toBe(true); // isolateDepth starts at 0
+
+    oneHop!.click();
+    flushSync();
+    expect(state.isolateDepth).toBe(1);
+    expect(oneHop!.classList.contains("active")).toBe(true);
+    expect(state.visibleSorted.map((n) => n.id).sort()).toEqual(["a", "b"]); // a-b are 1-hop neighbors
+
+    oneHop!.click(); // clicking the active depth again turns isolation off
+    flushSync();
+    expect(state.isolateDepth).toBe(0);
+
+    twoHop!.click();
+    flushSync();
+    expect(state.isolateDepth).toBe(2);
+    off!.click();
+    flushSync();
+    expect(state.isolateDepth).toBe(0);
+  });
+
+  test("switching directly between depths, and re-clicking 2-hop while active, both work", () => {
+    const state = createVizState(model());
+    state.selectConcept("a");
+    mountC(IsolateControl, { viz: state });
+    const [oneHop, twoHop] = [...document.querySelectorAll("#isolate .seg")] as HTMLElement[];
+
+    oneHop!.click(); // 0 -> 1
+    flushSync();
+    expect(state.isolateDepth).toBe(1);
+    twoHop!.click(); // 1 -> 2 directly, not via off
+    flushSync();
+    expect(state.isolateDepth).toBe(2);
+    expect(twoHop!.classList.contains("active")).toBe(true);
+    twoHop!.click(); // clicking the active 2-hop button again turns it off
+    flushSync();
+    expect(state.isolateDepth).toBe(0);
   });
 });
 

--- a/scripts/okf/viz-app/components.test.ts
+++ b/scripts/okf/viz-app/components.test.ts
@@ -87,6 +87,64 @@ describe("Legend", () => {
     flushSync();
     expect(state.hidden.size).toBe(0);
   });
+
+  test("renders one group header (both fixture types are root ids -> Knowledge)", () => {
+    const state = createVizState(model());
+    mountC(Legend, { viz: state });
+    const groups = [...document.querySelectorAll(".leg-group")];
+    expect(groups.map((g) => g.textContent?.trim())).toEqual(["Knowledge"]);
+  });
+
+  test("group header click toggles every type in the group; alt-click solos the group", () => {
+    const groupModel = buildModel({
+      nodes: [
+        node("decisions/x", "Decision", "X"),
+        node("patterns/y", "Pattern", "Y"),
+        node("modules/z", "Darwin Module", "Z"),
+      ],
+      edges: [],
+    });
+    const state = createVizState(groupModel);
+    mountC(Legend, { viz: state });
+    const headers = [...document.querySelectorAll(".leg-group")] as HTMLElement[];
+    expect(headers.map((h) => h.textContent?.trim())).toEqual(["Knowledge", "System"]);
+
+    headers[0]!.click(); // toggle Knowledge off
+    flushSync();
+    expect(state.hidden.has("Decision")).toBe(true);
+    expect(state.hidden.has("Pattern")).toBe(true);
+    expect(state.hidden.has("Darwin Module")).toBe(false);
+    headers[0]!.click(); // toggle back on
+    flushSync();
+    expect(state.hidden.size).toBe(0);
+
+    headers[0]!.dispatchEvent(new MouseEvent("click", { altKey: true, bubbles: true })); // solo Knowledge
+    flushSync();
+    expect(state.hidden.has("Darwin Module")).toBe(true);
+    expect(state.hidden.has("Decision")).toBe(false);
+    expect(state.hidden.has("Pattern")).toBe(false);
+  });
+
+  test("a fully-hidden group's header dims, matching its child rows", () => {
+    const groupModel = buildModel({
+      nodes: [
+        node("decisions/x", "Decision", "X"),
+        node("patterns/y", "Pattern", "Y"),
+        node("modules/z", "Darwin Module", "Z"),
+      ],
+      edges: [],
+    });
+    const state = createVizState(groupModel);
+    mountC(Legend, { viz: state });
+    const headers = [...document.querySelectorAll(".leg-group")] as HTMLElement[];
+    expect(headers.some((h) => h.classList.contains("off"))).toBe(false);
+    headers[0]!.click(); // hide Knowledge entirely
+    flushSync();
+    const knowledge = [...document.querySelectorAll(".leg-group")].find((h) => h.textContent?.trim() === "Knowledge")!;
+    const system = [...document.querySelectorAll(".leg-group")].find((h) => h.textContent?.trim() === "System")!;
+    expect(knowledge.classList.contains("off")).toBe(true);
+    expect(system.classList.contains("off")).toBe(false);
+  });
 });
 
 describe("ConceptList", () => {

--- a/scripts/okf/viz-app/data.test.ts
+++ b/scripts/okf/viz-app/data.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, test } from "bun:test";
-import { buildModel, dirOf } from "./data";
+import { buildModel, dirOf, neighborsWithin } from "./data";
 import { node } from "./test-helpers";
 
 const raw = {
@@ -121,5 +121,37 @@ describe("grouping", () => {
       edges: [],
     });
     expect(reversed.typeGroup["Nix Package"]).toBe("Other"); // still the FIRST node's group, not overwritten by the second
+  });
+});
+
+describe("neighborsWithin", () => {
+  const nRaw = {
+    nodes: [node("a", "Decision", "A"), node("b", "Pattern", "B"), node("c", "Pattern", "C"), node("d", "Pattern", "D")],
+    edges: [
+      { s: "a", t: "b" },
+      { s: "b", t: "c" },
+    ],
+  };
+  const nm = buildModel(nRaw);
+
+  test("1-hop includes the origin and direct neighbors only", () => {
+    expect(neighborsWithin(nm, "a", 1)).toEqual(new Set(["a", "b"]));
+  });
+
+  test("2-hop reaches through one more edge", () => {
+    expect(neighborsWithin(nm, "a", 2)).toEqual(new Set(["a", "b", "c"]));
+  });
+
+  test("a disconnected node returns just itself", () => {
+    expect(neighborsWithin(nm, "d", 1)).toEqual(new Set(["d"]));
+  });
+
+  test("an unknown id returns an empty set", () => {
+    expect(neighborsWithin(nm, "nope", 1)).toEqual(new Set());
+  });
+
+  test("depth 2 finds no further growth once the 1-hop set is already closed", () => {
+    // "b" (middle of a-b-c) already reaches its whole component at depth 1.
+    expect(neighborsWithin(nm, "b", 2)).toEqual(new Set(["a", "b", "c"]));
   });
 });

--- a/scripts/okf/viz-app/data.test.ts
+++ b/scripts/okf/viz-app/data.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, test } from "bun:test";
-import { buildModel } from "./data";
+import { buildModel, dirOf } from "./data";
 import { node } from "./test-helpers";
 
 const raw = {
@@ -49,5 +49,77 @@ describe("buildModel", () => {
     expect(empty.dirs).toEqual({});
     expect(empty.repoUrl).toBeNull();
     expect(empty.commits).toEqual({});
+  });
+});
+
+describe("grouping", () => {
+  const groupedRaw = {
+    nodes: [
+      node("decisions/x", "Decision", "X"),
+      node("patterns/y", "Pattern", "Y"),
+      node("modules/z", "Darwin Module", "Z"),
+      node("hosts/w", "Host", "W"),
+      node("packages/p", "Nix Package", "P"),
+      node("nvim/n", "Neovim Plugin", "N"),
+      node("mystery/m", "Mystery Type", "M"), // unmapped dir -> Other
+    ],
+    edges: [],
+  };
+  const gm = buildModel(groupedRaw);
+
+  test("dirOf derives the top-level bundle directory, root docs are '.'", () => {
+    expect(dirOf("decisions/x")).toBe("decisions");
+    expect(dirOf("okf-profile")).toBe(".");
+  });
+
+  test("typeGroup buckets each type by its concepts' directory", () => {
+    expect(gm.typeGroup).toEqual({
+      Decision: "Knowledge",
+      Pattern: "Knowledge",
+      "Darwin Module": "System",
+      Host: "System",
+      "Nix Package": "Packages",
+      "Neovim Plugin": "Neovim",
+      "Mystery Type": "Other",
+    });
+  });
+
+  test("groupOrder is GROUP_ORDER filtered to present groups, Other trailing", () => {
+    expect(gm.groupOrder).toEqual(["Knowledge", "System", "Packages", "Neovim", "Other"]);
+  });
+
+  test("groupTypes lists member types in allTypes (TYPE_ORDER-first) order", () => {
+    expect(gm.groupTypes["Knowledge"]).toEqual(["Pattern", "Decision"]);
+    expect(gm.groupTypes["System"]).toEqual(["Darwin Module", "Host"]);
+    expect(gm.groupTypes["Packages"]).toEqual(["Nix Package"]);
+    expect(gm.groupTypes["Neovim"]).toEqual(["Neovim Plugin"]);
+    expect(gm.groupTypes["Other"]).toEqual(["Mystery Type"]);
+  });
+
+  test("a bundle with no unmapped directory has no Other group", () => {
+    const clean = buildModel({ nodes: [node("decisions/x", "Decision", "X")], edges: [] });
+    expect(clean.groupOrder).toEqual(["Knowledge"]);
+    expect(clean.groupTypes["Other"]).toBeUndefined();
+  });
+
+  test("groupOrder filters out missing core groups even when Other is also present", () => {
+    const partial = buildModel({
+      nodes: [node("decisions/x", "Decision", "X"), node("mystery/m", "Mystery Type", "M")],
+      edges: [],
+    });
+    expect(partial.groupOrder).toEqual(["Knowledge", "Other"]); // System/Packages/Neovim absent, not phantom-included
+  });
+
+  test("typeGroup is stable: the first node of a type fixes its group, not the last", () => {
+    const firstWins = buildModel({
+      nodes: [node("packages/a", "Nix Package", "A"), node("flakes/b", "Nix Package", "B")],
+      edges: [],
+    });
+    expect(firstWins.typeGroup["Nix Package"]).toBe("Packages");
+    const reversed = buildModel({
+      nodes: [node("flakes/b", "Nix Package", "B"), node("packages/a", "Nix Package", "A")],
+      edges: [],
+    });
+    expect(reversed.typeGroup["Nix Package"]).toBe("Other"); // still the FIRST node's group, not overwritten by the second
   });
 });

--- a/scripts/okf/viz-app/data.test.ts
+++ b/scripts/okf/viz-app/data.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, test } from "bun:test";
-import { buildModel, dirOf, neighborsWithin } from "./data";
+import { buildModel, dirOf, neighborsWithin, parsePackagePlatforms, platformOf } from "./data";
 import { node } from "./test-helpers";
 
 const raw = {
@@ -153,5 +153,121 @@ describe("neighborsWithin", () => {
   test("depth 2 finds no further growth once the 1-hop set is already closed", () => {
     // "b" (middle of a-b-c) already reaches its whole component at depth 1.
     expect(neighborsWithin(nm, "b", 2)).toEqual(new Set(["a", "b", "c"]));
+  });
+});
+
+describe("parsePackagePlatforms", () => {
+  // Mirrors modules/packages.nix's shape: a `${system}` interpolation (whose '}'
+  // would truncate a lazy regex, dropping later attrs) plus inline `{ }` callPackage args.
+  const nix = `
+  packages = {
+    iv = pkgs.callPackage ../pkgs/iv.nix { };
+    tomato = pkgs.callPackage ../pkgs/tomato.nix { tomato-src = inputs.tomato; };
+    ccglass = inputs.ccglass.packages.\${system}.ccglass;
+  }
+  // lib.optionalAttrs (system == "aarch64-darwin") {
+    apple-container = inputs.apple-container.packages.\${system}.apple-container;
+    podman = pkgs.callPackage ../pkgs/podman.nix { };
+    kitten = pkgs.callPackage ../pkgs/kitten.nix { };
+    // A guarded package with a MULTI-LINE nested arg: its own-line \`packaged-src =\`
+    // must NOT be captured as a top-level package (depth-aware extraction).
+    packaged = pkgs.callPackage ../pkgs/packaged.nix {
+      packaged-src = inputs.packaged;
+    };
+  }
+  // lib.optionalAttrs (lib.hasSuffix "linux" system) {
+    flatpak-user = pkgs.callPackage ../pkgs/flatpak-user.nix { };
+    wowup = pkgs.callPackage ../pkgs/wowup.nix { };
+  };
+`;
+
+  test("classifies both guarded blocks, no attrs dropped past a \${system} '}'", () => {
+    expect(parsePackagePlatforms(nix)).toEqual({
+      "apple-container": "darwin",
+      podman: "darwin",
+      kitten: "darwin",
+      packaged: "darwin",
+      "flatpak-user": "nixos",
+      wowup: "nixos",
+    });
+    // Universal packages (outside any optionalAttrs block) are absent -> "both".
+    expect(parsePackagePlatforms(nix)["iv"]).toBeUndefined();
+    // A nested callPackage-arg attr on its own line is NOT captured as a package.
+    expect(parsePackagePlatforms(nix)["packaged-src"]).toBeUndefined();
+    // The tomato-src nested arg in the universal block is likewise never scanned.
+    expect(parsePackagePlatforms(nix)["tomato-src"]).toBeUndefined();
+  });
+
+  test("absent/garbage input yields an empty map (packages default to both)", () => {
+    expect(parsePackagePlatforms("")).toEqual({});
+    expect(parsePackagePlatforms("no optionalAttrs here { just: braces }")).toEqual({});
+  });
+
+  test("an unbalanced (truncated) block bails instead of misclassifying", () => {
+    expect(parsePackagePlatforms('// lib.optionalAttrs (system == "aarch64-darwin") { podman = x;')).toEqual({});
+  });
+});
+
+describe("platformOf", () => {
+  const pkg = { kitten: "darwin", "flatpak-user": "nixos" } as const;
+
+  test("modules derive from type", () => {
+    expect(platformOf("Darwin Module", "modules/nh", {})).toBe("darwin");
+    expect(platformOf("NixOS Module", "modules/keyring", {})).toBe("nixos");
+    expect(platformOf("Dual Module", "modules/tmux", {})).toBe("both");
+    expect(platformOf("Flake-parts Module", "modules/flake-parts", {})).toBe("both");
+  });
+
+  test("neovim is universal, knowledge is neutral", () => {
+    expect(platformOf("Neovim Plugin", "nvim/plugins/blink", {})).toBe("both");
+    expect(platformOf("Neovim Config", "nvim/keymaps", {})).toBe("both");
+    expect(platformOf("Decision", "decisions/x", {})).toBe("neutral");
+    expect(platformOf("Reference", "okf-profile", {})).toBe("neutral");
+  });
+
+  test("hosts derive from host id (only nebula is nixos)", () => {
+    expect(platformOf("Host", "hosts/nebula", {})).toBe("nixos");
+    expect(platformOf("Host", "hosts/k", {})).toBe("darwin");
+    expect(platformOf("Host", "hosts/SOC-Kris-Williams", {})).toBe("darwin");
+  });
+
+  test("packages/sub-flakes/overlays look up the guard by basename, default both", () => {
+    expect(platformOf("Nix Package", "packages/kitten", pkg)).toBe("darwin");
+    expect(platformOf("Nix Package", "packages/flatpak-user", pkg)).toBe("nixos");
+    expect(platformOf("Nix Package", "packages/iv", pkg)).toBe("both"); // universal
+    expect(platformOf("Sub-flake", "packages/ccglass", pkg)).toBe("both");
+    expect(platformOf("Overlay", "packages/direnv", pkg)).toBe("both");
+  });
+
+  test("unknown types default to neutral (never hidden by an OS filter)", () => {
+    expect(platformOf("Some Future Type", "x/y", {})).toBe("neutral");
+  });
+});
+
+describe("buildModel.platformById", () => {
+  test("derives a platform for every node from type/host/package guards", () => {
+    const m = buildModel({
+      nodes: [
+        node("modules/nh", "Darwin Module", "nh"),
+        node("modules/keyring", "NixOS Module", "keyring"),
+        node("packages/kitten", "Nix Package", "kitten"),
+        node("packages/iv", "Nix Package", "iv"),
+        node("decisions/x", "Decision", "X"),
+      ],
+      edges: [],
+      pkgPlatforms: { kitten: "darwin" },
+    });
+    expect(m.platformById).toEqual({
+      "modules/nh": "darwin",
+      "modules/keyring": "nixos",
+      "packages/kitten": "darwin",
+      "packages/iv": "both",
+      "decisions/x": "neutral",
+    });
+  });
+
+  test("missing pkgPlatforms defaults every package to both", () => {
+    const m = buildModel({ nodes: [node("packages/kitten", "Nix Package", "kitten")], edges: [] });
+    expect(m.platformById["packages/kitten"]).toBe("both");
   });
 });

--- a/scripts/okf/viz-app/data.ts
+++ b/scripts/okf/viz-app/data.ts
@@ -42,7 +42,11 @@ export interface RawData {
   repoUrl?: string | null;
   /** Verified commit-hash citations: literal as written -> full oid. */
   commits?: Record<string, string>;
+  /** Package name -> platform for OS-guarded packages (parsed from modules/packages.nix). */
+  pkgPlatforms?: Record<string, "darwin" | "nixos">;
 }
+
+export type Platform = "darwin" | "nixos" | "both" | "neutral";
 
 export interface VizModel {
   nodes: ConceptNode[];
@@ -66,6 +70,8 @@ export interface VizModel {
   groupTypes: Record<string, string[]>;
   /** GROUP_ORDER filtered to present clusters, "Other" appended only if non-empty. */
   groupOrder: string[];
+  /** OS a concept applies to, per node id (derived from type/host/package guards). */
+  platformById: Record<string, Platform>;
   /** Scene sphere radius per node (same order as nodes). */
   radii: number[];
 }
@@ -111,6 +117,82 @@ export const GROUP_OF_DIR: Record<string, string> = {
 
 export const GROUP_ORDER = ["Knowledge", "System", "Packages", "Neovim"];
 
+// The repo's only nixos host; every other host is darwin. Extend if a second
+// nixos host appears (same maintenance model as GROUP_OF_DIR).
+const NIXOS_HOSTS = new Set(["nebula"]);
+
+const basename = (id: string) => id.split("/").pop() ?? id;
+
+/**
+ * Package-name -> OS for the OS-guarded packages in modules/packages.nix.
+ * The file has two `lib.optionalAttrs (<pred>) { <attrs> }` blocks — one
+ * darwin-guarded, one linux-guarded; everything outside them is universal
+ * (absent from the map -> "both"). Brace-depth scan, not a lazy regex: an
+ * attr RHS like `inputs.x.packages.${system}.x` contains a `}` that would
+ * truncate a non-greedy capture and silently drop later attrs. Any structural
+ * change to the file degrades the affected packages to "both" — never throws.
+ */
+export function parsePackagePlatforms(nixSource: string): Record<string, "darwin" | "nixos"> {
+  const out: Record<string, "darwin" | "nixos"> = {};
+  const re = /optionalAttrs\s*\(([^{]*)\{/g; // predicate text up to the block-opening brace
+  for (let m = re.exec(nixSource); m; m = re.exec(nixSource)) {
+    const pred = m[1]!;
+    const os: "darwin" | "nixos" | null = pred.includes("darwin")
+      ? "darwin"
+      : pred.includes("linux")
+        ? "nixos"
+        : null;
+    if (!os) continue;
+    // Scan from just after the '{' to its matching close (depth 0).
+    let depth = 1;
+    let i = m.index + m[0].length;
+    for (; i < nixSource.length && depth > 0; i++) {
+      const c = nixSource[i];
+      if (c === "{") depth++;
+      else if (c === "}") depth--;
+    }
+    if (depth !== 0) continue; // unbalanced (EOF) — bail, don't misclassify
+    // Keep only the block's depth-0 text: dropping every nested `{...}` (callPackage
+    // args, `${system}` interps) means a nested `arg =` on its own line can never be
+    // mistaken for a top-level package attr.
+    let d = 0;
+    let top = "";
+    for (const c of nixSource.slice(m.index + m[0].length, i - 1)) {
+      if (c === "{") d++;
+      else if (c === "}") d--;
+      else if (d === 0) top += c;
+    }
+    for (const a of top.matchAll(/(?:^|\n)[ \t]*([A-Za-z][\w-]*)[ \t]*=/g)) out[a[1]!] = os;
+    re.lastIndex = i; // resume after this block
+  }
+  return out;
+}
+
+/** OS a concept applies to, derived from its type, id, and the package guards. */
+export function platformOf(type: string, id: string, pkgPlatforms: Record<string, "darwin" | "nixos">): Platform {
+  switch (type) {
+    case "Darwin Module":
+      return "darwin";
+    case "NixOS Module":
+      return "nixos";
+    case "Dual Module":
+    case "Flake-parts Module":
+    case "Neovim Plugin":
+    case "Neovim Config":
+      return "both";
+    case "Host":
+      return NIXOS_HOSTS.has(basename(id)) ? "nixos" : "darwin";
+    case "Nix Package":
+    case "Sub-flake":
+    case "Overlay":
+      return pkgPlatforms[basename(id)] ?? "both";
+    default:
+      // Decision/Pattern/Playbook/Reference and any unknown type: cross-cutting,
+      // never hidden by an OS filter.
+      return "neutral";
+  }
+}
+
 export function buildModel(raw: RawData): VizModel {
   const nodes = raw.nodes;
   const files = raw.files || {};
@@ -152,6 +234,10 @@ export function buildModel(raw: RawData): VizModel {
   for (const t of allTypes) (groupTypes[typeGroup[t]!] ??= []).push(t);
   const groupOrder = [...GROUP_ORDER.filter((g) => groupTypes[g]), ...(groupTypes["Other"] ? ["Other"] : [])];
 
+  const pkgPlatforms = raw.pkgPlatforms ?? {};
+  const platformById: Record<string, Platform> = {};
+  for (const n of nodes) platformById[n.id] = platformOf(n.type, n.id, pkgPlatforms);
+
   const radii = nodes.map((n) => (3.5 + Math.min(6.5, (deg[n.id] || 0) * 0.8)) * 0.42);
 
   return {
@@ -172,6 +258,7 @@ export function buildModel(raw: RawData): VizModel {
     typeGroup,
     groupTypes,
     groupOrder,
+    platformById,
     radii,
   };
 }

--- a/scripts/okf/viz-app/data.ts
+++ b/scripts/okf/viz-app/data.ts
@@ -56,6 +56,8 @@ export interface VizModel {
   edgeIdx: [number, number][];
   deg: Record<string, number>;
   inLinks: Record<string, string[]>;
+  /** Undirected adjacency by id, for neighborhood isolation. */
+  adjById: Record<string, Set<string>>;
   typeCounts: Record<string, number>;
   allTypes: string[];
   /** Legend cluster per type, derived from each type's concepts' top-level bundle directory. */
@@ -122,10 +124,14 @@ export function buildModel(raw: RawData): VizModel {
 
   const deg: Record<string, number> = {};
   const inLinks: Record<string, string[]> = {};
+  const adjById: Record<string, Set<string>> = {};
+  for (const n of nodes) adjById[n.id] = new Set();
   for (const e of edges) {
     deg[e.s] = (deg[e.s] || 0) + 1;
     deg[e.t] = (deg[e.t] || 0) + 1;
     (inLinks[e.t] = inLinks[e.t] || []).push(e.s);
+    adjById[e.s]!.add(e.t);
+    adjById[e.t]!.add(e.s);
   }
 
   const typeCounts: Record<string, number> = {};
@@ -160,6 +166,7 @@ export function buildModel(raw: RawData): VizModel {
     edgeIdx,
     deg,
     inLinks,
+    adjById,
     typeCounts,
     allTypes,
     typeGroup,
@@ -167,6 +174,29 @@ export function buildModel(raw: RawData): VizModel {
     groupOrder,
     radii,
   };
+}
+
+/** BFS neighbor set within `depth` hops of `id`, including `id` itself so the
+ *  origin never vanishes from its own filtered view. An id absent from the
+ *  model returns an empty set; a real but edge-less node returns itself. */
+export function neighborsWithin(model: VizModel, id: string, depth: 1 | 2): Set<string> {
+  const seen = new Set<string>();
+  if (!model.adjById[id]) return seen;
+  seen.add(id);
+  let frontier = [id];
+  for (let d = 0; d < depth; d++) {
+    const next: string[] = [];
+    for (const cur of frontier) {
+      for (const nb of model.adjById[cur] ?? []) {
+        if (!seen.has(nb)) {
+          seen.add(nb);
+          next.push(nb);
+        }
+      }
+    }
+    frontier = next;
+  }
+  return seen;
 }
 
 export function loadFromDom(): VizModel {

--- a/scripts/okf/viz-app/data.ts
+++ b/scripts/okf/viz-app/data.ts
@@ -58,6 +58,12 @@ export interface VizModel {
   inLinks: Record<string, string[]>;
   typeCounts: Record<string, number>;
   allTypes: string[];
+  /** Legend cluster per type, derived from each type's concepts' top-level bundle directory. */
+  typeGroup: Record<string, string>;
+  /** Types per legend cluster, in allTypes order. */
+  groupTypes: Record<string, string[]>;
+  /** GROUP_ORDER filtered to present clusters, "Other" appended only if non-empty. */
+  groupOrder: string[];
   /** Scene sphere radius per node (same order as nodes). */
   radii: number[];
 }
@@ -79,6 +85,29 @@ export const TYPE_ORDER = [
   "Overlay",
   "Reference",
 ];
+
+// A concept's id is its bundle-relative path minus ".md" (viz.ts) — the
+// top-level path segment is already a stable, zero-maintenance topology
+// signal. Root docs (no '/') group as ".".
+export function dirOf(id: string): string {
+  return id.includes("/") ? id.split("/")[0]! : ".";
+}
+
+// Static, append-only map from a top-level bundle directory to its legend
+// cluster. A directory not listed here buckets into "Other" (buildModel)
+// instead of crashing — a safety net for a future top-level directory.
+export const GROUP_OF_DIR: Record<string, string> = {
+  decisions: "Knowledge",
+  patterns: "Knowledge",
+  playbooks: "Knowledge",
+  ".": "Knowledge",
+  modules: "System",
+  hosts: "System",
+  packages: "Packages",
+  nvim: "Neovim",
+};
+
+export const GROUP_ORDER = ["Knowledge", "System", "Packages", "Neovim"];
 
 export function buildModel(raw: RawData): VizModel {
   const nodes = raw.nodes;
@@ -108,9 +137,36 @@ export function buildModel(raw: RawData): VizModel {
       .sort(),
   ];
 
+  // The profile keeps every type inside one top-level directory, so this is
+  // normally unambiguous; if that's ever violated, the first concept of a
+  // type fixes its group (deterministic, not "last write wins").
+  const typeGroup: Record<string, string> = {};
+  for (const n of nodes) typeGroup[n.type] ??= GROUP_OF_DIR[dirOf(n.id)] ?? "Other";
+  const groupTypes: Record<string, string[]> = {};
+  for (const t of allTypes) (groupTypes[typeGroup[t]!] ??= []).push(t);
+  const groupOrder = [...GROUP_ORDER.filter((g) => groupTypes[g]), ...(groupTypes["Other"] ? ["Other"] : [])];
+
   const radii = nodes.map((n) => (3.5 + Math.min(6.5, (deg[n.id] || 0) * 0.8)) * 0.42);
 
-  return { nodes, files, dirs, repoUrl, commits, byId, indexOf, edges, edgeIdx, deg, inLinks, typeCounts, allTypes, radii };
+  return {
+    nodes,
+    files,
+    dirs,
+    repoUrl,
+    commits,
+    byId,
+    indexOf,
+    edges,
+    edgeIdx,
+    deg,
+    inLinks,
+    typeCounts,
+    allTypes,
+    typeGroup,
+    groupTypes,
+    groupOrder,
+    radii,
+  };
 }
 
 export function loadFromDom(): VizModel {

--- a/scripts/okf/viz-app/hash.test.ts
+++ b/scripts/okf/viz-app/hash.test.ts
@@ -1,10 +1,11 @@
 import { describe, expect, test } from "bun:test";
-import { decodeHash, encodeHash } from "./hash";
+import { decodeHash, decodeViewHash, encodeHash, encodeViewHash } from "./hash";
 
 const model = {
   byId: { "nvim/architecture": {} },
-  files: { "scripts/okf/viz.ts": {}, "docs/50%.md": {} },
+  files: { "scripts/okf/viz.ts": {}, "docs/50%.md": {}, "docs/what?.md": {} },
   dirs: { "flakes/ccglass": {} },
+  typeCounts: { "Darwin Module": 2, Decision: 1 },
 };
 
 describe("encodeHash", () => {
@@ -17,6 +18,65 @@ describe("encodeHash", () => {
 
   test("literal '%' is escaped so the hash stays decodable", () => {
     expect(encodeHash({ kind: "file", path: "docs/50%.md" })).toBe("f/docs/50%25.md");
+  });
+
+  test("literal '?' is escaped so it can't read as the filter separator", () => {
+    expect(encodeHash({ kind: "file", path: "docs/what?.md" })).toBe("f/docs/what%3F.md");
+  });
+});
+
+describe("encodeViewHash", () => {
+  const none = { kind: "none" } as const;
+
+  test("empty filters add nothing", () => {
+    expect(encodeViewHash({ sel: none, filters: { hidden: [], q: "" } })).toBe("");
+    expect(
+      encodeViewHash({ sel: { kind: "concept", id: "nvim/architecture" }, filters: { hidden: [], q: "" } }),
+    ).toBe("c/nvim/architecture");
+  });
+
+  test("filters ride behind '?', hidden types sorted for a canonical form", () => {
+    expect(encodeViewHash({ sel: none, filters: { hidden: ["Decision", "Darwin Module"], q: "" } })).toBe(
+      "?hide=Darwin+Module%2CDecision",
+    );
+    expect(encodeViewHash({ sel: none, filters: { hidden: ["Darwin Module", "Decision"], q: "" } })).toBe(
+      "?hide=Darwin+Module%2CDecision",
+    );
+    expect(
+      encodeViewHash({ sel: { kind: "concept", id: "nvim/architecture" }, filters: { hidden: [], q: "tmux conf" } }),
+    ).toBe("c/nvim/architecture?q=tmux+conf");
+  });
+});
+
+describe("decodeViewHash", () => {
+  test("selection + filters round-trip, including '%' paths", () => {
+    for (const view of [
+      { sel: { kind: "concept", id: "nvim/architecture" }, filters: { hidden: ["Darwin Module", "Decision"], q: "" } },
+      { sel: { kind: "none" }, filters: { hidden: [], q: "a?b&c=%" } },
+      { sel: { kind: "file", path: "docs/50%.md" }, filters: { hidden: ["Decision"], q: "tmux" } },
+    ] as const) {
+      const decoded = decodeViewHash(encodeViewHash(view as never), model);
+      expect(decoded.sel).toEqual(view.sel);
+      expect(decoded.filters).toEqual(view.filters as never);
+    }
+  });
+
+  test("bare selection hashes decode with empty filters (old links stay valid)", () => {
+    expect(decodeViewHash("c/nvim/architecture", model)).toEqual({
+      sel: { kind: "concept", id: "nvim/architecture" },
+      filters: { hidden: [], q: "" },
+    });
+  });
+
+  test("unknown hidden types are dropped against the model", () => {
+    expect(decodeViewHash("?hide=Decision,Nope,", model).filters.hidden).toEqual(["Decision"]);
+  });
+
+  test("junk filter params fall back to empty filters", () => {
+    expect(decodeViewHash("c/nvim/architecture?%%%", model).sel).toEqual({
+      kind: "concept",
+      id: "nvim/architecture",
+    });
   });
 });
 

--- a/scripts/okf/viz-app/hash.test.ts
+++ b/scripts/okf/viz-app/hash.test.ts
@@ -27,46 +27,58 @@ describe("encodeHash", () => {
 
 describe("encodeViewHash", () => {
   const none = { kind: "none" } as const;
+  const f = (o: Partial<{ hidden: string[]; q: string; isolate: 0 | 1 | 2; platform: "all" | "darwin" | "nixos" }>) => ({
+    hidden: [],
+    q: "",
+    isolate: 0 as const,
+    platform: "all" as const,
+    ...o,
+  });
 
   test("empty filters add nothing", () => {
-    expect(encodeViewHash({ sel: none, filters: { hidden: [], q: "", isolate: 0 } })).toBe("");
-    expect(
-      encodeViewHash({ sel: { kind: "concept", id: "nvim/architecture" }, filters: { hidden: [], q: "", isolate: 0 } }),
-    ).toBe("c/nvim/architecture");
+    expect(encodeViewHash({ sel: none, filters: f({}) })).toBe("");
+    expect(encodeViewHash({ sel: { kind: "concept", id: "nvim/architecture" }, filters: f({}) })).toBe(
+      "c/nvim/architecture",
+    );
   });
 
   test("filters ride behind '?', hidden types sorted for a canonical form", () => {
-    expect(encodeViewHash({ sel: none, filters: { hidden: ["Decision", "Darwin Module"], q: "", isolate: 0 } })).toBe(
+    expect(encodeViewHash({ sel: none, filters: f({ hidden: ["Decision", "Darwin Module"] }) })).toBe(
       "?hide=Darwin+Module%2CDecision",
     );
-    expect(encodeViewHash({ sel: none, filters: { hidden: ["Darwin Module", "Decision"], q: "", isolate: 0 } })).toBe(
+    expect(encodeViewHash({ sel: none, filters: f({ hidden: ["Darwin Module", "Decision"] }) })).toBe(
       "?hide=Darwin+Module%2CDecision",
     );
-    expect(
-      encodeViewHash({
-        sel: { kind: "concept", id: "nvim/architecture" },
-        filters: { hidden: [], q: "tmux conf", isolate: 0 },
-      }),
-    ).toBe("c/nvim/architecture?q=tmux+conf");
+    expect(encodeViewHash({ sel: { kind: "concept", id: "nvim/architecture" }, filters: f({ q: "tmux conf" }) })).toBe(
+      "c/nvim/architecture?q=tmux+conf",
+    );
   });
 
   test("isolate rides behind '?' only for a concept selection and a nonzero depth", () => {
-    expect(
-      encodeViewHash({ sel: { kind: "concept", id: "nvim/architecture" }, filters: { hidden: [], q: "", isolate: 2 } }),
-    ).toBe("c/nvim/architecture?isolate=2");
-    expect(
-      encodeViewHash({ sel: { kind: "concept", id: "nvim/architecture" }, filters: { hidden: [], q: "", isolate: 0 } }),
-    ).toBe("c/nvim/architecture");
-    expect(encodeViewHash({ sel: none, filters: { hidden: [], q: "", isolate: 2 } })).toBe(""); // no selection -> never emitted
+    expect(encodeViewHash({ sel: { kind: "concept", id: "nvim/architecture" }, filters: f({ isolate: 2 }) })).toBe(
+      "c/nvim/architecture?isolate=2",
+    );
+    expect(encodeViewHash({ sel: { kind: "concept", id: "nvim/architecture" }, filters: f({ isolate: 0 }) })).toBe(
+      "c/nvim/architecture",
+    );
+    expect(encodeViewHash({ sel: none, filters: f({ isolate: 2 }) })).toBe(""); // no selection -> never emitted
   });
 
-  test("isolate is ordered after hide and q in the query string", () => {
+  test("platform rides behind '?' as os=, always emittable (no selection gate)", () => {
+    expect(encodeViewHash({ sel: none, filters: f({ platform: "darwin" }) })).toBe("?os=darwin");
+    expect(encodeViewHash({ sel: { kind: "file", path: "docs/50%.md" }, filters: f({ platform: "nixos" }) })).toBe(
+      "f/docs/50%25.md?os=nixos",
+    );
+    expect(encodeViewHash({ sel: none, filters: f({ platform: "all" }) })).toBe(""); // "all" omitted
+  });
+
+  test("hide, q, isolate, os appear in a stable order", () => {
     expect(
       encodeViewHash({
         sel: { kind: "concept", id: "nvim/architecture" },
-        filters: { hidden: ["Decision"], q: "arch", isolate: 1 },
+        filters: f({ hidden: ["Decision"], q: "arch", isolate: 1, platform: "darwin" }),
       }),
-    ).toBe("c/nvim/architecture?hide=Decision&q=arch&isolate=1");
+    ).toBe("c/nvim/architecture?hide=Decision&q=arch&isolate=1&os=darwin");
   });
 });
 
@@ -75,11 +87,11 @@ describe("decodeViewHash", () => {
     for (const view of [
       {
         sel: { kind: "concept", id: "nvim/architecture" },
-        filters: { hidden: ["Darwin Module", "Decision"], q: "", isolate: 0 },
+        filters: { hidden: ["Darwin Module", "Decision"], q: "", isolate: 0, platform: "all" },
       },
-      { sel: { kind: "none" }, filters: { hidden: [], q: "a?b&c=%", isolate: 0 } },
-      { sel: { kind: "file", path: "docs/50%.md" }, filters: { hidden: ["Decision"], q: "tmux", isolate: 0 } },
-      { sel: { kind: "concept", id: "nvim/architecture" }, filters: { hidden: ["Decision"], q: "tmux", isolate: 1 } },
+      { sel: { kind: "none" }, filters: { hidden: [], q: "a?b&c=%", isolate: 0, platform: "darwin" } },
+      { sel: { kind: "file", path: "docs/50%.md" }, filters: { hidden: ["Decision"], q: "tmux", isolate: 0, platform: "nixos" } },
+      { sel: { kind: "concept", id: "nvim/architecture" }, filters: { hidden: ["Decision"], q: "tmux", isolate: 1, platform: "darwin" } },
     ] as const) {
       const decoded = decodeViewHash(encodeViewHash(view as never), model);
       expect(decoded.sel).toEqual(view.sel);
@@ -90,7 +102,7 @@ describe("decodeViewHash", () => {
   test("bare selection hashes decode with empty filters (old links stay valid)", () => {
     expect(decodeViewHash("c/nvim/architecture", model)).toEqual({
       sel: { kind: "concept", id: "nvim/architecture" },
-      filters: { hidden: [], q: "", isolate: 0 },
+      filters: { hidden: [], q: "", isolate: 0, platform: "all" },
     });
   });
 
@@ -113,6 +125,14 @@ describe("decodeViewHash", () => {
   test("garbage isolate values clamp to 0", () => {
     expect(decodeViewHash("c/nvim/architecture?isolate=3", model).filters.isolate).toBe(0);
     expect(decodeViewHash("c/nvim/architecture?isolate=abc", model).filters.isolate).toBe(0);
+  });
+
+  test("os= decodes for any selection kind; invalid values clamp to 'all'", () => {
+    expect(decodeViewHash("?os=darwin", model).filters.platform).toBe("darwin");
+    expect(decodeViewHash("f/scripts/okf/viz.ts?os=nixos", model).filters.platform).toBe("nixos");
+    expect(decodeViewHash("d/flakes/ccglass?os=darwin", model).filters.platform).toBe("darwin");
+    expect(decodeViewHash("c/nvim/architecture?os=bogus", model).filters.platform).toBe("all");
+    expect(decodeViewHash("c/nvim/architecture", model).filters.platform).toBe("all");
   });
 });
 

--- a/scripts/okf/viz-app/hash.test.ts
+++ b/scripts/okf/viz-app/hash.test.ts
@@ -29,31 +29,57 @@ describe("encodeViewHash", () => {
   const none = { kind: "none" } as const;
 
   test("empty filters add nothing", () => {
-    expect(encodeViewHash({ sel: none, filters: { hidden: [], q: "" } })).toBe("");
+    expect(encodeViewHash({ sel: none, filters: { hidden: [], q: "", isolate: 0 } })).toBe("");
     expect(
-      encodeViewHash({ sel: { kind: "concept", id: "nvim/architecture" }, filters: { hidden: [], q: "" } }),
+      encodeViewHash({ sel: { kind: "concept", id: "nvim/architecture" }, filters: { hidden: [], q: "", isolate: 0 } }),
     ).toBe("c/nvim/architecture");
   });
 
   test("filters ride behind '?', hidden types sorted for a canonical form", () => {
-    expect(encodeViewHash({ sel: none, filters: { hidden: ["Decision", "Darwin Module"], q: "" } })).toBe(
+    expect(encodeViewHash({ sel: none, filters: { hidden: ["Decision", "Darwin Module"], q: "", isolate: 0 } })).toBe(
       "?hide=Darwin+Module%2CDecision",
     );
-    expect(encodeViewHash({ sel: none, filters: { hidden: ["Darwin Module", "Decision"], q: "" } })).toBe(
+    expect(encodeViewHash({ sel: none, filters: { hidden: ["Darwin Module", "Decision"], q: "", isolate: 0 } })).toBe(
       "?hide=Darwin+Module%2CDecision",
     );
     expect(
-      encodeViewHash({ sel: { kind: "concept", id: "nvim/architecture" }, filters: { hidden: [], q: "tmux conf" } }),
+      encodeViewHash({
+        sel: { kind: "concept", id: "nvim/architecture" },
+        filters: { hidden: [], q: "tmux conf", isolate: 0 },
+      }),
     ).toBe("c/nvim/architecture?q=tmux+conf");
+  });
+
+  test("isolate rides behind '?' only for a concept selection and a nonzero depth", () => {
+    expect(
+      encodeViewHash({ sel: { kind: "concept", id: "nvim/architecture" }, filters: { hidden: [], q: "", isolate: 2 } }),
+    ).toBe("c/nvim/architecture?isolate=2");
+    expect(
+      encodeViewHash({ sel: { kind: "concept", id: "nvim/architecture" }, filters: { hidden: [], q: "", isolate: 0 } }),
+    ).toBe("c/nvim/architecture");
+    expect(encodeViewHash({ sel: none, filters: { hidden: [], q: "", isolate: 2 } })).toBe(""); // no selection -> never emitted
+  });
+
+  test("isolate is ordered after hide and q in the query string", () => {
+    expect(
+      encodeViewHash({
+        sel: { kind: "concept", id: "nvim/architecture" },
+        filters: { hidden: ["Decision"], q: "arch", isolate: 1 },
+      }),
+    ).toBe("c/nvim/architecture?hide=Decision&q=arch&isolate=1");
   });
 });
 
 describe("decodeViewHash", () => {
   test("selection + filters round-trip, including '%' paths", () => {
     for (const view of [
-      { sel: { kind: "concept", id: "nvim/architecture" }, filters: { hidden: ["Darwin Module", "Decision"], q: "" } },
-      { sel: { kind: "none" }, filters: { hidden: [], q: "a?b&c=%" } },
-      { sel: { kind: "file", path: "docs/50%.md" }, filters: { hidden: ["Decision"], q: "tmux" } },
+      {
+        sel: { kind: "concept", id: "nvim/architecture" },
+        filters: { hidden: ["Darwin Module", "Decision"], q: "", isolate: 0 },
+      },
+      { sel: { kind: "none" }, filters: { hidden: [], q: "a?b&c=%", isolate: 0 } },
+      { sel: { kind: "file", path: "docs/50%.md" }, filters: { hidden: ["Decision"], q: "tmux", isolate: 0 } },
+      { sel: { kind: "concept", id: "nvim/architecture" }, filters: { hidden: ["Decision"], q: "tmux", isolate: 1 } },
     ] as const) {
       const decoded = decodeViewHash(encodeViewHash(view as never), model);
       expect(decoded.sel).toEqual(view.sel);
@@ -64,7 +90,7 @@ describe("decodeViewHash", () => {
   test("bare selection hashes decode with empty filters (old links stay valid)", () => {
     expect(decodeViewHash("c/nvim/architecture", model)).toEqual({
       sel: { kind: "concept", id: "nvim/architecture" },
-      filters: { hidden: [], q: "" },
+      filters: { hidden: [], q: "", isolate: 0 },
     });
   });
 
@@ -77,6 +103,16 @@ describe("decodeViewHash", () => {
       kind: "concept",
       id: "nvim/architecture",
     });
+  });
+
+  test("a stray isolate= on a non-concept selection is dropped on decode", () => {
+    expect(decodeViewHash("?isolate=2", model).filters.isolate).toBe(0);
+    expect(decodeViewHash("f/scripts/okf/viz.ts?isolate=1", model).filters.isolate).toBe(0);
+  });
+
+  test("garbage isolate values clamp to 0", () => {
+    expect(decodeViewHash("c/nvim/architecture?isolate=3", model).filters.isolate).toBe(0);
+    expect(decodeViewHash("c/nvim/architecture?isolate=abc", model).filters.isolate).toBe(0);
   });
 });
 

--- a/scripts/okf/viz-app/hash.ts
+++ b/scripts/okf/viz-app/hash.ts
@@ -1,8 +1,9 @@
 // URL-hash codec for viewer state. The selection is the path segment
 // (`c/<concept-id>` | `f/<file-path>` | `d/<dir-path>`); view filters ride
 // behind a `?` as query params (`hide=<type,type,…>` + `q=<search>` +
-// `isolate=<1|2>`, the last only meaningful for a concept selection), so a
-// shared link reproduces the whole lens, not just the selection.
+// `isolate=<1|2>`, the last only meaningful for a concept selection, +
+// `os=<darwin|nixos>`), so a shared link reproduces the whole lens, not just
+// the selection.
 // Pure — validation against the data model is injected by the caller.
 
 export type Selection =
@@ -18,6 +19,8 @@ export interface ViewFilters {
   q: string;
   /** Neighborhood isolation depth (0 = off); only meaningful for a concept selection. */
   isolate: 0 | 1 | 2;
+  /** OS lens ("all" = off). */
+  platform: "all" | "darwin" | "nixos";
 }
 
 export interface ViewState {
@@ -53,6 +56,8 @@ export function encodeViewHash(view: ViewState): string {
   if (view.filters.hidden.length) p.set("hide", [...view.filters.hidden].sort().join(","));
   if (view.filters.q) p.set("q", view.filters.q);
   if (view.sel.kind === "concept" && view.filters.isolate) p.set("isolate", String(view.filters.isolate));
+  const plat = view.filters.platform ?? "all";
+  if (plat !== "all") p.set("os", plat);
   const qs = p.toString();
   return encodeHash(view.sel) + (qs ? "?" + qs : "");
 }
@@ -74,7 +79,7 @@ export function decodeViewHash(raw: string, model: HashModel): ViewState {
   const bare = raw.replace(/^#/, "");
   const qi = bare.indexOf("?");
   const sel = decodeHash(qi < 0 ? bare : bare.slice(0, qi), model);
-  const filters: ViewFilters = { hidden: [], q: "", isolate: 0 };
+  const filters: ViewFilters = { hidden: [], q: "", isolate: 0, platform: "all" };
   if (qi >= 0) {
     const p = new URLSearchParams(bare.slice(qi + 1));
     const hide = p.get("hide");
@@ -82,6 +87,8 @@ export function decodeViewHash(raw: string, model: HashModel): ViewState {
     filters.q = p.get("q") ?? "";
     const iv = p.get("isolate");
     filters.isolate = sel.kind !== "concept" ? 0 : iv === "1" ? 1 : iv === "2" ? 2 : 0;
+    const os = p.get("os");
+    filters.platform = os === "darwin" || os === "nixos" ? os : "all";
   }
   return { sel, filters };
 }

--- a/scripts/okf/viz-app/hash.ts
+++ b/scripts/okf/viz-app/hash.ts
@@ -1,6 +1,7 @@
 // URL-hash codec for viewer state. The selection is the path segment
 // (`c/<concept-id>` | `f/<file-path>` | `d/<dir-path>`); view filters ride
-// behind a `?` as query params (`hide=<type,type,…>` + `q=<search>`), so a
+// behind a `?` as query params (`hide=<type,type,…>` + `q=<search>` +
+// `isolate=<1|2>`, the last only meaningful for a concept selection), so a
 // shared link reproduces the whole lens, not just the selection.
 // Pure — validation against the data model is injected by the caller.
 
@@ -15,6 +16,8 @@ export interface ViewFilters {
   hidden: string[];
   /** Search box contents. */
   q: string;
+  /** Neighborhood isolation depth (0 = off); only meaningful for a concept selection. */
+  isolate: 0 | 1 | 2;
 }
 
 export interface ViewState {
@@ -49,6 +52,7 @@ export function encodeViewHash(view: ViewState): string {
   // Type names contain no ','; the registry (okf-profile.md) keeps it that way.
   if (view.filters.hidden.length) p.set("hide", [...view.filters.hidden].sort().join(","));
   if (view.filters.q) p.set("q", view.filters.q);
+  if (view.sel.kind === "concept" && view.filters.isolate) p.set("isolate", String(view.filters.isolate));
   const qs = p.toString();
   return encodeHash(view.sel) + (qs ? "?" + qs : "");
 }
@@ -70,12 +74,14 @@ export function decodeViewHash(raw: string, model: HashModel): ViewState {
   const bare = raw.replace(/^#/, "");
   const qi = bare.indexOf("?");
   const sel = decodeHash(qi < 0 ? bare : bare.slice(0, qi), model);
-  const filters: ViewFilters = { hidden: [], q: "" };
+  const filters: ViewFilters = { hidden: [], q: "", isolate: 0 };
   if (qi >= 0) {
     const p = new URLSearchParams(bare.slice(qi + 1));
     const hide = p.get("hide");
     if (hide) filters.hidden = hide.split(",").filter((t) => t && (!model.typeCounts || t in model.typeCounts));
     filters.q = p.get("q") ?? "";
+    const iv = p.get("isolate");
+    filters.isolate = sel.kind !== "concept" ? 0 : iv === "1" ? 1 : iv === "2" ? 2 : 0;
   }
   return { sel, filters };
 }

--- a/scripts/okf/viz-app/hash.ts
+++ b/scripts/okf/viz-app/hash.ts
@@ -1,5 +1,7 @@
-// URL-hash codec for viewer selections:
-// `c/<concept-id>` | `f/<file-path>` | `d/<dir-path>`.
+// URL-hash codec for viewer state. The selection is the path segment
+// (`c/<concept-id>` | `f/<file-path>` | `d/<dir-path>`); view filters ride
+// behind a `?` as query params (`hide=<type,type,…>` + `q=<search>`), so a
+// shared link reproduces the whole lens, not just the selection.
 // Pure — validation against the data model is injected by the caller.
 
 export type Selection =
@@ -8,21 +10,47 @@ export type Selection =
   | { kind: "file"; path: string }
   | { kind: "dir"; path: string };
 
+export interface ViewFilters {
+  /** Concept types toggled off in the legend. */
+  hidden: string[];
+  /** Search box contents. */
+  q: string;
+}
+
+export interface ViewState {
+  sel: Selection;
+  filters: ViewFilters;
+}
+
 export interface HashModel {
   byId: Record<string, unknown>;
   files: Record<string, unknown>;
   dirs: Record<string, unknown>;
+  /** When present, unknown types in `hide=` are dropped on decode. */
+  typeCounts?: Record<string, number>;
 }
 
+// '%' breaks the decode round-trip and '?' would read as the filter
+// separator — escape both so ids/paths containing them survive the URL.
+// Browsers pass other fragment chars through (or add %XX that
+// decodeURIComponent restores).
+const enc = (s: string) => s.replace(/%/g, "%25").replace(/\?/g, "%3F");
+
 export function encodeHash(sel: Selection): string {
-  // '%' is the one character that breaks the decode round-trip — escape it so
-  // ids/paths containing it survive the URL. Browsers pass other fragment
-  // chars through (or add %XX that decodeURIComponent restores).
-  const enc = (s: string) => s.replace(/%/g, "%25");
   if (sel.kind === "concept") return "c/" + enc(sel.id);
   if (sel.kind === "file") return "f/" + enc(sel.path);
   if (sel.kind === "dir") return "d/" + enc(sel.path);
   return "";
+}
+
+/** Canonical form: hidden types sorted, empty filters omitted entirely. */
+export function encodeViewHash(view: ViewState): string {
+  const p = new URLSearchParams();
+  // Type names contain no ','; the registry (okf-profile.md) keeps it that way.
+  if (view.filters.hidden.length) p.set("hide", [...view.filters.hidden].sort().join(","));
+  if (view.filters.q) p.set("q", view.filters.q);
+  const qs = p.toString();
+  return encodeHash(view.sel) + (qs ? "?" + qs : "");
 }
 
 export function decodeHash(raw: string, model: HashModel): Selection {
@@ -36,4 +64,18 @@ export function decodeHash(raw: string, model: HashModel): Selection {
   if (h.startsWith("f/") && model.files[h.slice(2)]) return { kind: "file", path: h.slice(2) };
   if (h.startsWith("d/") && model.dirs[h.slice(2)]) return { kind: "dir", path: h.slice(2) };
   return { kind: "none" };
+}
+
+export function decodeViewHash(raw: string, model: HashModel): ViewState {
+  const bare = raw.replace(/^#/, "");
+  const qi = bare.indexOf("?");
+  const sel = decodeHash(qi < 0 ? bare : bare.slice(0, qi), model);
+  const filters: ViewFilters = { hidden: [], q: "" };
+  if (qi >= 0) {
+    const p = new URLSearchParams(bare.slice(qi + 1));
+    const hide = p.get("hide");
+    if (hide) filters.hidden = hide.split(",").filter((t) => t && (!model.typeCounts || t in model.typeCounts));
+    filters.q = p.get("q") ?? "";
+  }
+  return { sel, filters };
 }

--- a/scripts/okf/viz-app/state.svelte.ts
+++ b/scripts/okf/viz-app/state.svelte.ts
@@ -46,7 +46,11 @@ export function createVizState(model: VizModel) {
 
   const match = $derived.by(() => {
     const q = query.trim().toLowerCase();
-    return q ? (n: ConceptNode) => `${n.title} ${n.id} ${n.desc} ${n.type}`.toLowerCase().includes(q) : null;
+    if (!q) return null;
+    return (n: ConceptNode) => {
+      const tags = Array.isArray(n.fm.tags) ? n.fm.tags.join(" ") : "";
+      return `${n.title} ${n.id} ${n.desc} ${n.type} ${tags}`.toLowerCase().includes(q);
+    };
   });
 
   const computeSlots = () => {
@@ -64,6 +68,9 @@ export function createVizState(model: VizModel) {
 
   const visible = (n: ConceptNode) => !hidden.has(n.type) && (!match || match(n));
   const visibleSorted = $derived(model.nodes.filter(visible).sort((a, b) => a.title.localeCompare(b.title)));
+  // Search hits suppressed by type toggles, surfaced in the list so a hidden
+  // type never silently swallows a match.
+  const hiddenMatchCount = $derived(match ? model.nodes.filter((n) => hidden.has(n.type) && match(n)).length : 0);
 
   const selectedConcept = $derived(sel.kind === "concept" ? (model.byId[sel.id] ?? null) : null);
   const backConcept = $derived(lastConceptId ? (model.byId[lastConceptId] ?? null) : null);
@@ -118,6 +125,28 @@ export function createVizState(model: VizModel) {
     hidden,
     toggleType(t: string) {
       hidden.has(t) ? hidden.delete(t) : hidden.add(t);
+    },
+    showAllTypes() {
+      hidden.clear();
+    },
+    hideAllTypes() {
+      for (const t of model.allTypes) hidden.add(t);
+    },
+    /** Isolate one type; solo it again to restore all. */
+    soloType(t: string) {
+      const alone = !hidden.has(t) && hidden.size === model.allTypes.length - 1;
+      hidden.clear();
+      if (!alone) for (const u of model.allTypes) u !== t && hidden.add(u);
+    },
+    /** Replace the whole filter state (hash navigation). */
+    setFilters(hiddenTypes: string[], q: string) {
+      const want = new Set(hiddenTypes);
+      for (const t of [...hidden]) if (!want.has(t)) hidden.delete(t);
+      for (const t of want) hidden.add(t);
+      query = q;
+    },
+    get hiddenMatchCount() {
+      return hiddenMatchCount;
     },
 
     get query() {

--- a/scripts/okf/viz-app/state.svelte.ts
+++ b/scripts/okf/viz-app/state.svelte.ts
@@ -66,6 +66,14 @@ export function createVizState(model: VizModel) {
     paletteVersion++;
   };
 
+  /** Isolate a set of types; solo the same set again to restore all. */
+  const soloTypes = (types: string[]) => {
+    const want = new Set(types);
+    const alone = model.allTypes.every((u) => (want.has(u) ? !hidden.has(u) : hidden.has(u)));
+    hidden.clear();
+    if (!alone) for (const u of model.allTypes) if (!want.has(u)) hidden.add(u);
+  };
+
   const visible = (n: ConceptNode) => !hidden.has(n.type) && (!match || match(n));
   const visibleSorted = $derived(model.nodes.filter(visible).sort((a, b) => a.title.localeCompare(b.title)));
   // Search hits suppressed by type toggles, surfaced in the list so a hidden
@@ -132,11 +140,16 @@ export function createVizState(model: VizModel) {
     hideAllTypes() {
       for (const t of model.allTypes) hidden.add(t);
     },
-    /** Isolate one type; solo it again to restore all. */
     soloType(t: string) {
-      const alone = !hidden.has(t) && hidden.size === model.allTypes.length - 1;
-      hidden.clear();
-      if (!alone) for (const u of model.allTypes) u !== t && hidden.add(u);
+      soloTypes([t]);
+    },
+    toggleGroup(g: string) {
+      const types = model.groupTypes[g] ?? [];
+      const allHidden = types.length > 0 && types.every((t) => hidden.has(t));
+      for (const t of types) allHidden ? hidden.delete(t) : hidden.add(t);
+    },
+    soloGroup(g: string) {
+      soloTypes(model.groupTypes[g] ?? []);
     },
     /** Replace the whole filter state (hash navigation). */
     setFilters(hiddenTypes: string[], q: string) {

--- a/scripts/okf/viz-app/state.svelte.ts
+++ b/scripts/okf/viz-app/state.svelte.ts
@@ -2,7 +2,7 @@
 // Stage.svelte bridges it into the imperative GraphScene.
 import { SvelteSet } from "svelte/reactivity";
 import { nameColor } from "./color";
-import { TYPE_ORDER, type ConceptNode, type VizModel } from "./data";
+import { neighborsWithin, TYPE_ORDER, type ConceptNode, type VizModel } from "./data";
 import type { Selection } from "./hash";
 import { applyThemeVars, defaultThemeIndex, THEMES } from "./themes";
 
@@ -29,6 +29,7 @@ export function createVizState(model: VizModel) {
   let lastConceptId = $state<string | null>(null);
   const hidden = new SvelteSet<string>();
   let query = $state("");
+  let isolateDepth = $state<0 | 1 | 2>(0);
   let hover = $state<Hover | null>(null);
   let panelW = $state(typeof localStorage === "undefined" ? 0 : +(localStorage.getItem(PANEL_KEY) || 0));
   let dark = $state(typeof matchMedia === "undefined" ? false : matchMedia("(prefers-color-scheme: dark)").matches);
@@ -74,7 +75,8 @@ export function createVizState(model: VizModel) {
     if (!alone) for (const u of model.allTypes) if (!want.has(u)) hidden.add(u);
   };
 
-  const visible = (n: ConceptNode) => !hidden.has(n.type) && (!match || match(n));
+  const visible = (n: ConceptNode) =>
+    !hidden.has(n.type) && (!match || match(n)) && (!neighborIds || neighborIds.has(n.id));
   const visibleSorted = $derived(model.nodes.filter(visible).sort((a, b) => a.title.localeCompare(b.title)));
   // Search hits suppressed by type toggles, surfaced in the list so a hidden
   // type never silently swallows a match.
@@ -82,10 +84,13 @@ export function createVizState(model: VizModel) {
 
   const selectedConcept = $derived(sel.kind === "concept" ? (model.byId[sel.id] ?? null) : null);
   const backConcept = $derived(lastConceptId ? (model.byId[lastConceptId] ?? null) : null);
-  const sceneSelectedIndex = $derived.by(() => {
-    const id = sel.kind === "concept" ? sel.id : sel.kind === "file" || sel.kind === "dir" ? lastConceptId : null;
-    return id != null ? (model.indexOf.get(id) ?? null) : null;
-  });
+  const focusedConcept = $derived(selectedConcept ?? backConcept);
+  // Anchored on selectedConcept strictly (not focusedConcept): isolation is
+  // only meaningful while a concept, not a file/dir view, is the selection.
+  const neighborIds = $derived.by(() =>
+    isolateDepth && selectedConcept ? neighborsWithin(model, selectedConcept.id, isolateDepth) : null,
+  );
+  const sceneSelectedIndex = $derived(focusedConcept ? (model.indexOf.get(focusedConcept.id) ?? null) : null);
 
   return {
     model,
@@ -104,6 +109,9 @@ export function createVizState(model: VizModel) {
     },
     get backConcept() {
       return backConcept;
+    },
+    get focusedConcept() {
+      return focusedConcept;
     },
     get sceneSelectedIndex() {
       return sceneSelectedIndex;
@@ -128,6 +136,7 @@ export function createVizState(model: VizModel) {
       lastConceptId = null;
       fly = false;
       selSeq++;
+      isolateDepth = 0;
     },
 
     hidden,
@@ -152,14 +161,25 @@ export function createVizState(model: VizModel) {
       soloTypes(model.groupTypes[g] ?? []);
     },
     /** Replace the whole filter state (hash navigation). */
-    setFilters(hiddenTypes: string[], q: string) {
+    setFilters(hiddenTypes: string[], q: string, isolate: 0 | 1 | 2 = 0) {
       const want = new Set(hiddenTypes);
       for (const t of [...hidden]) if (!want.has(t)) hidden.delete(t);
       for (const t of want) hidden.add(t);
       query = q;
+      isolateDepth = isolate;
     },
     get hiddenMatchCount() {
       return hiddenMatchCount;
+    },
+
+    get isolateDepth() {
+      return isolateDepth;
+    },
+    setIsolate(depth: 0 | 1 | 2) {
+      isolateDepth = depth === 1 || depth === 2 ? depth : 0;
+    },
+    get neighborIds() {
+      return neighborIds;
     },
 
     get query() {

--- a/scripts/okf/viz-app/state.svelte.ts
+++ b/scripts/okf/viz-app/state.svelte.ts
@@ -30,6 +30,7 @@ export function createVizState(model: VizModel) {
   const hidden = new SvelteSet<string>();
   let query = $state("");
   let isolateDepth = $state<0 | 1 | 2>(0);
+  let platform = $state<"all" | "darwin" | "nixos">("all");
   let hover = $state<Hover | null>(null);
   let panelW = $state(typeof localStorage === "undefined" ? 0 : +(localStorage.getItem(PANEL_KEY) || 0));
   let dark = $state(typeof matchMedia === "undefined" ? false : matchMedia("(prefers-color-scheme: dark)").matches);
@@ -75,8 +76,13 @@ export function createVizState(model: VizModel) {
     if (!alone) for (const u of model.allTypes) if (!want.has(u)) hidden.add(u);
   };
 
+  const platformOk = (n: ConceptNode) => {
+    if (platform === "all") return true;
+    const p = model.platformById[n.id];
+    return p === "both" || p === "neutral" || p === platform;
+  };
   const visible = (n: ConceptNode) =>
-    !hidden.has(n.type) && (!match || match(n)) && (!neighborIds || neighborIds.has(n.id));
+    !hidden.has(n.type) && (!match || match(n)) && (!neighborIds || neighborIds.has(n.id)) && platformOk(n);
   const visibleSorted = $derived(model.nodes.filter(visible).sort((a, b) => a.title.localeCompare(b.title)));
   // Search hits suppressed by type toggles, surfaced in the list so a hidden
   // type never silently swallows a match.
@@ -161,12 +167,13 @@ export function createVizState(model: VizModel) {
       soloTypes(model.groupTypes[g] ?? []);
     },
     /** Replace the whole filter state (hash navigation). */
-    setFilters(hiddenTypes: string[], q: string, isolate: 0 | 1 | 2 = 0) {
+    setFilters(hiddenTypes: string[], q: string, isolate: 0 | 1 | 2 = 0, plat: "all" | "darwin" | "nixos" = "all") {
       const want = new Set(hiddenTypes);
       for (const t of [...hidden]) if (!want.has(t)) hidden.delete(t);
       for (const t of want) hidden.add(t);
       query = q;
       isolateDepth = isolate;
+      platform = plat;
     },
     get hiddenMatchCount() {
       return hiddenMatchCount;
@@ -180,6 +187,13 @@ export function createVizState(model: VizModel) {
     },
     get neighborIds() {
       return neighborIds;
+    },
+
+    get platform() {
+      return platform;
+    },
+    setPlatform(p: "all" | "darwin" | "nixos") {
+      platform = p === "darwin" || p === "nixos" ? p : "all";
     },
 
     get query() {

--- a/scripts/okf/viz-app/state.test.ts
+++ b/scripts/okf/viz-app/state.test.ts
@@ -208,6 +208,112 @@ describe("filtering", () => {
   });
 });
 
+describe("neighborhood isolation", () => {
+  const isoModel = () =>
+    buildModel({
+      nodes: [
+        node("a", "Decision", "Alpha"),
+        node("b", "Pattern", "Beta"),
+        node("c", "Pattern", "Gamma"),
+        node("d", "Pattern", "Delta"),
+      ],
+      edges: [
+        { s: "a", t: "b" },
+        { s: "b", t: "c" },
+      ],
+    });
+
+  test("setIsolate(1) restricts visibleSorted to the selection's 1-hop neighborhood", () => {
+    const s = createVizState(isoModel());
+    s.selectConcept("a");
+    s.setIsolate(1);
+    expect(s.visibleSorted.map((n) => n.id).sort()).toEqual(["a", "b"]);
+  });
+
+  test("setIsolate(2) reaches one more hop", () => {
+    const s = createVizState(isoModel());
+    s.selectConcept("a");
+    s.setIsolate(2);
+    expect(s.visibleSorted.map((n) => n.id).sort()).toEqual(["a", "b", "c"]);
+  });
+
+  test("isolation ANDs with type-hidden filters", () => {
+    const s = createVizState(isoModel());
+    s.selectConcept("a");
+    s.setIsolate(2);
+    s.toggleType("Pattern");
+    expect(s.visibleSorted.map((n) => n.id)).toEqual(["a"]); // b, c are Pattern, hidden by type too
+  });
+
+  test("clearSelection resets isolation", () => {
+    const s = createVizState(isoModel());
+    s.selectConcept("a");
+    s.setIsolate(2);
+    s.clearSelection();
+    expect(s.isolateDepth).toBe(0);
+    expect(s.visibleSorted).toHaveLength(4);
+  });
+
+  test("isolation is sticky across concept-to-concept navigation, re-rooting on the new selection", () => {
+    const s = createVizState(isoModel());
+    s.selectConcept("a");
+    s.setIsolate(1);
+    s.selectConcept("c");
+    expect(s.isolateDepth).toBe(1);
+    expect(s.visibleSorted.map((n) => n.id).sort()).toEqual(["b", "c"]);
+  });
+
+  test("setIsolate clamps invalid depths to 0", () => {
+    const s = createVizState(isoModel());
+    s.selectConcept("a");
+    s.setIsolate(3 as never);
+    expect(s.isolateDepth).toBe(0);
+  });
+
+  test("hiddenMatchCount ignores matches suppressed only by isolation, not type", () => {
+    const s = createVizState(isoModel());
+    s.selectConcept("a");
+    s.setIsolate(1); // neighborhood = {a, b}; c and d are isolation-hidden, no type hidden
+    s.query = "gamma"; // matches c, which is Pattern (not type-hidden) but outside the 1-hop neighborhood
+    expect(s.visibleSorted).toHaveLength(0); // c matches but isn't in the neighborhood
+    expect(s.hiddenMatchCount).toBe(0); // hiddenMatchCount only tracks type-hidden suppression
+  });
+
+  test("setFilters accepts an isolate depth, defaults to 0 for existing 2-arg calls", () => {
+    const s = createVizState(isoModel());
+    s.selectConcept("a");
+    s.setFilters(["Pattern"], "");
+    expect(s.isolateDepth).toBe(0);
+    s.setFilters([], "", 2);
+    expect(s.isolateDepth).toBe(2);
+  });
+
+  test("opening a file/dir view suspends isolation (anchored on selectedConcept, not focusedConcept)", () => {
+    const s = createVizState(model()); // a-b edge, plus a file and a dir to select
+    s.selectConcept("a");
+    s.setIsolate(1);
+    expect(s.visibleSorted.map((n) => n.id).sort()).toEqual(["a", "b"]);
+    s.selectFile("scripts/okf/viz.ts");
+    expect(s.isolateDepth).toBe(1); // sticky: not reset by selectFile
+    expect(s.neighborIds).toBeNull(); // but inactive: selectedConcept is null while a file view is open
+    expect(s.visibleSorted).toHaveLength(3); // isolation stops restricting the list
+    s.selectDir("flakes/ccglass");
+    expect(s.neighborIds).toBeNull();
+    expect(s.visibleSorted).toHaveLength(3);
+  });
+});
+
+describe("focusedConcept", () => {
+  test("is the selection, or the last concept while a file/dir view is open", () => {
+    const s = createVizState(model());
+    expect(s.focusedConcept).toBeNull();
+    s.selectConcept("a");
+    expect(s.focusedConcept?.id).toBe("a");
+    s.selectFile("scripts/okf/viz.ts");
+    expect(s.focusedConcept?.id).toBe("a");
+  });
+});
+
 describe("panel width", () => {
   test("default clamp: min(460, 85%) capped at 92%", () => {
     const s = createVizState(model());

--- a/scripts/okf/viz-app/state.test.ts
+++ b/scripts/okf/viz-app/state.test.ts
@@ -6,7 +6,7 @@ import { node } from "./test-helpers";
 const model = () =>
   buildModel({
     nodes: [
-      node("a", "Decision", "Alpha", { desc: "first decision" }),
+      node("a", "Decision", "Alpha", { desc: "first decision", fm: { tags: ["stow", "symlinks"] } }),
       node("b", "Pattern", "Beta"),
       node("c", "Decision", "Gamma"),
     ],
@@ -75,13 +75,15 @@ describe("filtering", () => {
     expect(s.visibleSorted).toHaveLength(3);
   });
 
-  test("query matches title/id/desc/type, case-insensitive", () => {
+  test("query matches title/id/desc/type/tags, case-insensitive", () => {
     const s = createVizState(model());
     s.query = "ALPHA";
     expect(s.visibleSorted.map((n) => n.id)).toEqual(["a"]);
     s.query = "pattern";
     expect(s.visibleSorted.map((n) => n.id)).toEqual(["b"]);
     s.query = "first decision";
+    expect(s.visibleSorted.map((n) => n.id)).toEqual(["a"]);
+    s.query = "symlink";
     expect(s.visibleSorted.map((n) => n.id)).toEqual(["a"]);
     s.query = "";
     expect(s.visibleSorted).toHaveLength(3);
@@ -90,6 +92,49 @@ describe("filtering", () => {
   test("visibleSorted sorts by title", () => {
     const s = createVizState(model());
     expect(s.visibleSorted.map((n) => n.title)).toEqual(["Alpha", "Beta", "Gamma"]);
+  });
+
+  test("showAllTypes / hideAllTypes", () => {
+    const s = createVizState(model());
+    s.hideAllTypes();
+    expect(s.visibleSorted).toHaveLength(0);
+    expect(s.hidden.size).toBe(2); // Decision + Pattern
+    s.showAllTypes();
+    expect(s.visibleSorted).toHaveLength(3);
+  });
+
+  test("soloType isolates, re-solo restores, solo elsewhere switches", () => {
+    const s = createVizState(model());
+    s.soloType("Decision");
+    expect(s.visibleSorted.map((n) => n.id)).toEqual(["a", "c"]);
+    s.soloType("Pattern"); // switch the solo, not additive
+    expect(s.visibleSorted.map((n) => n.id)).toEqual(["b"]);
+    s.soloType("Pattern"); // solo again = restore all
+    expect(s.visibleSorted).toHaveLength(3);
+  });
+
+  test("setFilters replaces hidden set and query wholesale", () => {
+    const s = createVizState(model());
+    s.toggleType("Pattern");
+    s.setFilters(["Decision"], "gamma");
+    expect([...s.hidden]).toEqual(["Decision"]);
+    expect(s.query).toBe("gamma");
+    s.setFilters([], "");
+    expect(s.hidden.size).toBe(0);
+    expect(s.visibleSorted).toHaveLength(3);
+  });
+
+  test("hiddenMatchCount counts search hits suppressed by type toggles", () => {
+    const s = createVizState(model());
+    expect(s.hiddenMatchCount).toBe(0);
+    s.toggleType("Decision");
+    expect(s.hiddenMatchCount).toBe(0); // no query — nothing "swallowed"
+    s.query = "gamma";
+    expect(s.visibleSorted).toHaveLength(0);
+    expect(s.hiddenMatchCount).toBe(1);
+    s.showAllTypes();
+    expect(s.hiddenMatchCount).toBe(0);
+    expect(s.visibleSorted.map((n) => n.id)).toEqual(["c"]);
   });
 });
 

--- a/scripts/okf/viz-app/state.test.ts
+++ b/scripts/okf/viz-app/state.test.ts
@@ -314,6 +314,68 @@ describe("focusedConcept", () => {
   });
 });
 
+describe("platform axis", () => {
+  const platModel = () =>
+    buildModel({
+      nodes: [
+        node("modules/nh", "Darwin Module", "Nh"),
+        node("modules/keyring", "NixOS Module", "Keyring"),
+        node("modules/tmux", "Dual Module", "Tmux"),
+        node("decisions/x", "Decision", "Decide"),
+      ],
+      edges: [],
+    });
+
+  test("default is 'all' — every node visible", () => {
+    const s = createVizState(platModel());
+    expect(s.platform).toBe("all");
+    expect(s.visibleSorted).toHaveLength(4);
+  });
+
+  test("darwin lens shows darwin + both + neutral, hides nixos-only", () => {
+    const s = createVizState(platModel());
+    s.setPlatform("darwin");
+    expect(s.visibleSorted.map((n) => n.id).sort()).toEqual(["decisions/x", "modules/nh", "modules/tmux"]);
+  });
+
+  test("nixos lens shows nixos + both + neutral, hides darwin-only", () => {
+    const s = createVizState(platModel());
+    s.setPlatform("nixos");
+    expect(s.visibleSorted.map((n) => n.id).sort()).toEqual(["decisions/x", "modules/keyring", "modules/tmux"]);
+  });
+
+  test("composes via AND with type and search filters", () => {
+    const s = createVizState(platModel());
+    s.setPlatform("darwin"); // {nh, tmux, x}
+    s.toggleType("Dual Module"); // remove tmux -> {nh, x}
+    expect(s.visibleSorted.map((n) => n.id).sort()).toEqual(["decisions/x", "modules/nh"]);
+    s.query = "nh"; // -> {nh}
+    expect(s.visibleSorted.map((n) => n.id)).toEqual(["modules/nh"]);
+  });
+
+  test("setPlatform clamps invalid values to 'all'", () => {
+    const s = createVizState(platModel());
+    s.setPlatform("bogus" as never);
+    expect(s.platform).toBe("all");
+  });
+
+  test("platform is a global lens: it does NOT reset on clearSelection", () => {
+    const s = createVizState(platModel());
+    s.selectConcept("modules/nh");
+    s.setPlatform("darwin");
+    s.clearSelection();
+    expect(s.platform).toBe("darwin"); // unlike isolate, which resets
+  });
+
+  test("setFilters accepts a platform (4th arg), defaults to 'all'", () => {
+    const s = createVizState(platModel());
+    s.setFilters([], "", 0, "nixos");
+    expect(s.platform).toBe("nixos");
+    s.setFilters([], "");
+    expect(s.platform).toBe("all");
+  });
+});
+
 describe("panel width", () => {
   test("default clamp: min(460, 85%) capped at 92%", () => {
     const s = createVizState(model());

--- a/scripts/okf/viz-app/state.test.ts
+++ b/scripts/okf/viz-app/state.test.ts
@@ -124,6 +124,76 @@ describe("filtering", () => {
     expect(s.visibleSorted).toHaveLength(3);
   });
 
+  test("toggleGroup/soloGroup act across every type in the group, leaving other groups untouched", () => {
+    const groupModel = () =>
+      buildModel({
+        nodes: [
+          node("decisions/x", "Decision", "X"),
+          node("patterns/y", "Pattern", "Y"),
+          node("modules/z", "Darwin Module", "Z"),
+        ],
+        edges: [],
+      });
+    const s = createVizState(groupModel());
+    s.toggleGroup("Knowledge"); // Decision + Pattern
+    expect(s.visibleSorted.map((n) => n.id)).toEqual(["modules/z"]);
+    s.toggleGroup("Knowledge");
+    expect(s.visibleSorted).toHaveLength(3);
+
+    s.soloGroup("Knowledge"); // hides every other group's types (System here)
+    expect(s.visibleSorted.map((n) => n.id).sort()).toEqual(["decisions/x", "patterns/y"]);
+    s.soloGroup("Knowledge"); // solo again restores all
+    expect(s.visibleSorted).toHaveLength(3);
+  });
+
+  test("toggleGroup escalates a partially-hidden group to fully hidden, never un-hides", () => {
+    const groupModel = () =>
+      buildModel({
+        nodes: [
+          node("decisions/x", "Decision", "X"),
+          node("patterns/y", "Pattern", "Y"),
+          node("modules/z", "Darwin Module", "Z"),
+        ],
+        edges: [],
+      });
+    const s = createVizState(groupModel());
+    s.toggleType("Decision"); // mixed state: Decision hidden, Pattern visible, both in Knowledge
+    s.toggleGroup("Knowledge");
+    expect(s.hidden.has("Decision")).toBe(true); // stays hidden
+    expect(s.hidden.has("Pattern")).toBe(true); // escalates to fully hidden, not un-hidden
+  });
+
+  test("soloGroup hides every other group when 3+ groups are present", () => {
+    const threeGroupModel = () =>
+      buildModel({
+        nodes: [
+          node("decisions/x", "Decision", "X"),
+          node("modules/z", "Darwin Module", "Z"),
+          node("packages/p", "Nix Package", "P"),
+        ],
+        edges: [],
+      });
+    const s = createVizState(threeGroupModel());
+    s.soloGroup("Knowledge");
+    expect(s.hidden.has("Darwin Module")).toBe(true);
+    expect(s.hidden.has("Nix Package")).toBe(true);
+    expect(s.hidden.has("Decision")).toBe(false);
+    s.soloGroup("Knowledge"); // restore
+    expect(s.hidden.size).toBe(0);
+  });
+
+  test("toggleGroup on an absent group name is a no-op", () => {
+    const s = createVizState(model());
+    s.toggleGroup("NoSuchGroup");
+    expect(s.hidden.size).toBe(0);
+  });
+
+  test("soloGroup on an absent group name hides everything (soloing an empty set shows nothing)", () => {
+    const s = createVizState(model());
+    s.soloGroup("NoSuchGroup");
+    expect(s.visibleSorted).toHaveLength(0);
+  });
+
   test("hiddenMatchCount counts search hits suppressed by type toggles", () => {
     const s = createVizState(model());
     expect(s.hiddenMatchCount).toBe(0);

--- a/scripts/okf/viz.ts
+++ b/scripts/okf/viz.ts
@@ -11,6 +11,7 @@ import { existsSync, readFileSync, statSync, writeFileSync } from "node:fs";
 import { extname, join } from "node:path";
 import { bundleRoot, extractLinks, gitISO, gitTrackedFiles, githubRemoteUrl, isExternal, parseDoc, repoRoot, resolveCommits, resolveLink, walkMd, RESERVED } from "./lib";
 import { layout3d } from "./layout3d";
+import { parsePackagePlatforms } from "./viz-app/data";
 import { esc } from "./viz-app/markdown";
 import { THEMES } from "./viz-app/themes";
 
@@ -244,6 +245,10 @@ for (const n of nodes) for (const m of n.body.matchAll(HASH_SPAN)) hashCandidate
 for (const f of Object.values(files)) if (f.md) for (const m of f.md.matchAll(HASH_SPAN)) hashCandidates.add(m[1]);
 const repoUrl = githubRemoteUrl();
 const commits = repoUrl ? resolveCommits([...hashCandidates]) : {};
+// OS guards for the platform filter: parse the darwin/linux `optionalAttrs`
+// blocks in modules/packages.nix (absent file -> {} -> every package "both").
+const packagesNix = join(repo, "modules", "packages.nix");
+const pkgPlatforms = existsSync(packagesNix) ? parsePackagePlatforms(readFileSync(packagesNix, "utf8")) : {};
 lap("sources");
 
 // --- Frozen 3D layout ---------------------------------------------------------
@@ -283,7 +288,10 @@ for (const o of build.outputs) if (o.path.endsWith(".css")) appCss += await o.te
 appCss = appCss.replace(/<\/style/gi, "<\\/style");
 lap("bundle");
 
-const data = JSON.stringify({ nodes, edges: dedupedEdges, files, dirs, repoUrl, commits }).replace(/<\//g, "<\\/");
+const data = JSON.stringify({ nodes, edges: dedupedEdges, files, dirs, repoUrl, commits, pkgPlatforms }).replace(
+  /<\//g,
+  "<\\/",
+);
 
 /** :root custom-property block for a named theme stop, from the app's THEMES. */
 const themeCss = (name: string) =>
@@ -313,6 +321,24 @@ const html = `<!doctype html>
     font: 14px/1.45 system-ui, -apple-system, "Segoe UI", sans-serif;
     color: var(--ink-1); background: var(--page);
     display: grid; grid-template-columns: 260px 1fr; overflow: hidden;
+  }
+  /* Shared sidebar-control primitives (used by the legend head, the platform
+     and neighborhood segmented controls) — global so the controls don't each
+     re-declare an identical scoped copy. */
+  .hint {
+    margin-right: auto;
+    color: var(--ink-muted); font-size: 11px;
+    text-transform: uppercase; letter-spacing: 0.05em;
+  }
+  .seg {
+    padding: 2px 6px; font: inherit; font-size: 12px;
+    color: var(--ink-muted); background: none;
+    border: 1px solid transparent; border-radius: 5px; cursor: pointer;
+  }
+  .seg:hover { color: var(--ink-1); }
+  .seg.active {
+    color: var(--ink-1); border-color: var(--grid);
+    background: var(--page); font-weight: 600;
   }
 </style>
 <style>${appCss}</style>


### PR DESCRIPTION
## Summary

Overhauls the `okf viz` knowledge-graph sidebar filtering, which was a flat 14-type legend + a nebulous search box with no bulk controls. Bundles three stacked phases (A → B → C) into one merge. The result is **four composable filter axes sharing one shareable URL lens**:

- **Type** — the legend groups its 14 types into 4 topology clusters (Knowledge / System / Packages / Neovim), with all/none, click-to-toggle, and alt-click-to-solo at both the group and type level.
- **Search** — matches title / id / description / **tags** (previously only the first three, invisibly); honest placeholder; hits hidden by a type filter surface as a clickable "+n hidden" note instead of silently vanishing.
- **Neighborhood** — selecting a concept reveals a `1-hop / 2-hop / off` control that restricts the graph (and the 3D scene's dimming) to that concept's graph neighborhood.
- **Platform** — a segmented `all | darwin | nixos` lens filtering by which OS a concept applies to.

The whole lens (hidden types, query, isolation depth, platform) rides the URL hash, so reload, Back/Forward, and links shared to <https://kris.net/dotfiles/> reproduce the exact view. Filter-only changes use `replaceState` (no per-keystroke history churn); selection changes still push.

## Phases

**A — quick wins** (`9cf8a00`): legend all/none + alt-click-solo, tag-aware search, live "n of 131" counts, the hidden-by-type note, and the filter lens in the URL.

**B — grouped legend + neighborhood isolation** (`d703845`, `ab889a9`): the 4-cluster legend derived from each concept's bundle directory (zero hand-authored taxonomy), and 1/2-hop neighborhood isolation composed via AND with the type/search filters, sticky across concept navigation.

**C — platform axis** (`4c5b62f`): the darwin/nixos segmented control. Platform is **derived from repo structure**, not hand-authored: modules by `type`, hosts by host-id, nvim = both, knowledge = neutral, and packages by parsing the darwin/linux `lib.optionalAttrs` guards in `modules/packages.nix` (a depth-aware brace scan run at build time by `viz.ts`). Known limitation: `noctalia-config`/`helium-config` build unconditionally so they classify `both` despite being Linux-desktop tools — the direct consequence of deriving from build structure.

## Design decisions (deferred, not dropped)

- No `platform:` frontmatter — the axis is derived, matching the group axis's zero-maintenance ethos.
- Knowledge docs stay `neutral` (no per-doc platform lean).
- No collapsible legend groups (4 groups / ~18 rows don't need it yet) and no isolation/platform-suppressed-matches note (only the type-filter note exists).

## Verification

Each phase went through a plan → implement → **multi-agent verify-and-review workflow** (svelte-check + a real headless-Chrome interaction drive in parallel with a 3-dimension adversarial code review, every finding independently verified before applying). That process caught and fixed real issues pre-merge — a non-deterministic legend-group assignment, a misleading sidebar count during inactive isolation, a `${system}` brace-scan hazard in the package parser, and more.

- **157 bun tests** pass (`cd scripts/okf && bun test`), up from the pre-existing suite.
- `okf viz --check` (svelte-check) clean; `okf validate` clean.
- Driven end-to-end in headless Chrome, including a 3D-scene instanceColor probe confirming the scene re-dims on every axis.

`knowledge/viz.html` is gitignored (regenerated by `okf viz`), so it is not in this diff.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
