### PR TITLE
okf: typecheck on tsgo via svelte-check's experimental API

### DIFF
--- a/flakes/okf/README.md
+++ b/flakes/okf/README.md
@@ -108,9 +108,16 @@ bun test
 bun okf.ts help
 ```
 
-**Dev-tree only** (not available from the nix-built package, whose
-`node_modules` is a read-only store path):
+**Dev-tree only** (not available from the nix-built package):
 
-- `okf viz --check` — spawns `bunx svelte-check`, which writes
-  `node_modules/.svelte2tsx-language-server-files` at startup.
 - `okf viz --perf` — needs a locally installed Chrome (puppeteer-core).
+
+`okf viz --check` typechecks with tsgo (`@typescript/native-preview`) through
+svelte-check's `--tsgo-experimental-api` — in-process and artifact-free, so it
+works from the nix-built package too (the tsc path wrote
+`node_modules/.svelte2tsx-language-server-files`, impossible on a read-only
+store path). Plain-TS iteration is fastest with tsgo directly:
+`bunx tsgo --noEmit -p tsconfig.json` (checks everything but `.svelte` files).
+Known upstream gap: svelte-check 4.7.1's non-API `--tsgo` flag points at
+`bin/tsgo.js`, which current native-preview builds no longer ship — it exits 0
+without checking anything; don't use it.

--- a/flakes/okf/bun.lock
+++ b/flakes/okf/bun.lock
@@ -13,6 +13,7 @@
         "@happy-dom/global-registrator": "^20.10.6",
         "@types/bun": "^1.3.14",
         "@types/three": "^0.185.0",
+        "@typescript/native-preview": "^7.0.0-dev.20260704.1",
         "bun-plugin-svelte": "^0.0.6",
         "happy-dom": "^20.10.6",
         "puppeteer-core": "^25.3.0",
@@ -61,6 +62,22 @@
     "@types/whatwg-mimetype": ["@types/whatwg-mimetype@3.0.2", "", {}, "sha512-c2AKvDT8ToxLIOUlN51gTiHXflsfIFisS4pO7pDPoKouJCESkhZnEy623gwP9laCy5lnLDAw1vAzu2vM2YLOrA=="],
 
     "@types/ws": ["@types/ws@8.18.1", "", { "dependencies": { "@types/node": "*" } }, "sha512-ThVF6DCVhA8kUGy+aazFQ4kXQ7E1Ty7A3ypFOe0IcJV8O/M511G99AW24irKrW56Wt44yG9+ij8FaqoBGkuBXg=="],
+
+    "@typescript/native-preview": ["@typescript/native-preview@7.0.0-dev.20260704.1", "", { "optionalDependencies": { "@typescript/native-preview-darwin-arm64": "7.0.0-dev.20260704.1", "@typescript/native-preview-darwin-x64": "7.0.0-dev.20260704.1", "@typescript/native-preview-linux-arm": "7.0.0-dev.20260704.1", "@typescript/native-preview-linux-arm64": "7.0.0-dev.20260704.1", "@typescript/native-preview-linux-x64": "7.0.0-dev.20260704.1", "@typescript/native-preview-win32-arm64": "7.0.0-dev.20260704.1", "@typescript/native-preview-win32-x64": "7.0.0-dev.20260704.1" }, "bin": { "tsgo": "bin/tsgo" } }, "sha512-B8CxdI0CumQVV9/9COcanWCWJmu8Jm1kMuYvse3iGm5ay9QrKTD+qyb11x8SPKUMtiUqnhNxt0n4ESNt+LQMuQ=="],
+
+    "@typescript/native-preview-darwin-arm64": ["@typescript/native-preview-darwin-arm64@7.0.0-dev.20260704.1", "", { "os": "darwin", "cpu": "arm64" }, "sha512-WHNMx8HTka+2w9ZifYbfkHHyQBzO+MCbOLQzNJE3K7A7mYJ1aq6ZEvBhRcNqixjKAIIO4U34KQvaQ6PXlwezkQ=="],
+
+    "@typescript/native-preview-darwin-x64": ["@typescript/native-preview-darwin-x64@7.0.0-dev.20260704.1", "", { "os": "darwin", "cpu": "x64" }, "sha512-IZJib4da/+3gRVSQFoQU1uFzsiSXnI02xBZljipDoPwahRcOdjH9gJ7DMBFbZ53pUtN5lvqbpES4oXiJZTneDA=="],
+
+    "@typescript/native-preview-linux-arm": ["@typescript/native-preview-linux-arm@7.0.0-dev.20260704.1", "", { "os": "linux", "cpu": "arm" }, "sha512-Dkz8oqvg4nEIu2Acz/d+iBDhIIOqjaAJ6mo6a2diRrDI+K5NAHljTzvkclCxgz6WIa5JnUY3kWzy8jE5AtaCQg=="],
+
+    "@typescript/native-preview-linux-arm64": ["@typescript/native-preview-linux-arm64@7.0.0-dev.20260704.1", "", { "os": "linux", "cpu": "arm64" }, "sha512-rjyHYAmDQ68NZIpU5i46D50hgQ63UJGGN/LJv3DAPWC8KraNonS5j4fN2bH/V+acQV9l/sS3+US1daV8VkQaFQ=="],
+
+    "@typescript/native-preview-linux-x64": ["@typescript/native-preview-linux-x64@7.0.0-dev.20260704.1", "", { "os": "linux", "cpu": "x64" }, "sha512-y2L2eNwCgrTgXKMol9n/bSPeyNHwJbrUDAv6/J7/087yhPNCt61l3KbpiGAYs0KYcCt3V2lNSDtS3geHQfSWJQ=="],
+
+    "@typescript/native-preview-win32-arm64": ["@typescript/native-preview-win32-arm64@7.0.0-dev.20260704.1", "", { "os": "win32", "cpu": "arm64" }, "sha512-PzBVRs8UNSAqtoCp9BtT1jsG4SSOfuDT1yo8Z3gGevmNtKEFZjb92BTSnBZaMPPQkM22fq83zgrAEVOEENIicw=="],
+
+    "@typescript/native-preview-win32-x64": ["@typescript/native-preview-win32-x64@7.0.0-dev.20260704.1", "", { "os": "win32", "cpu": "x64" }, "sha512-wb/C+fqWpXAoJZd8KQZdpjOq67v/cmLsApjL9oHjC1X6zqz7AzyOQ486uxWT6LvYzKkar4A+iq8h5h+PNgN38w=="],
 
     "acorn": ["acorn@8.17.0", "", { "bin": { "acorn": "bin/acorn" } }, "sha512-xRQbDb9BnwDafYNn6Vwl839DYVjqXYb1XVGtWAZ1kcDc6iwAL4hg3B1dZlRiuENFeO2H53gFG3in621AdERVAg=="],
 

--- a/flakes/okf/package.json
+++ b/flakes/okf/package.json
@@ -11,6 +11,7 @@
     "@happy-dom/global-registrator": "^20.10.6",
     "@types/bun": "^1.3.14",
     "@types/three": "^0.185.0",
+    "@typescript/native-preview": "^7.0.0-dev.20260704.1",
     "bun-plugin-svelte": "^0.0.6",
     "happy-dom": "^20.10.6",
     "puppeteer-core": "^25.3.0",

--- a/flakes/okf/package.nix
+++ b/flakes/okf/package.nix
@@ -55,9 +55,10 @@ let
     fileset = sources;
   };
 
-  # The lock is pure JS — no os/cpu-conditional packages, no install scripts —
-  # so one hash serves every platform; --cpu/--os="*" keeps that true if a
-  # future dep adds conditionals. NOT --production: `okf viz` needs svelte +
+  # One hash serves every platform: --cpu/--os="*" makes bun install every
+  # platform variant of os/cpu-conditional packages (@typescript/native-preview
+  # ships a ~26M tsgo binary per platform — the bulk of this output's size).
+  # No install scripts run. NOT --production: `okf viz` needs svelte +
   # bun-plugin-svelte (devDependencies) at CLI runtime, the tests happy-dom.
   # Refresh the hash (bun.lock or nixpkgs bun changes): set lib.fakeHash, then
   # `nix build ./flakes/okf#okf.node_modules` and copy the "got:" value.
@@ -98,7 +99,7 @@ let
     # Fixup would patch shebangs into store paths — forbidden in a fixed-output
     # derivation.
     dontFixup = true;
-    outputHash = "sha256-bkxkmTnRRePRqyHN3pq/TNW8CjqkQCLaJm5y55ri2OA=";
+    outputHash = "sha256-NBnA/LycPFkpSkvkpZCv6dmK8v6Da6OAI5ADYq7TuAI=";
     outputHashAlgo = "sha256";
     outputHashMode = "recursive";
   };

--- a/flakes/okf/viz.ts
+++ b/flakes/okf/viz.ts
@@ -21,12 +21,19 @@ import { THEMES } from "./viz-app/themes";
 const argv = process.argv.slice(2);
 
 // --check: typecheck the viewer app (svelte-check) instead of building.
+// TS diagnostics come from tsgo (@typescript/native-preview) via svelte-check's
+// experimental API — in-process, no `node` spawn, no disk artifacts, ~2x faster
+// than the tsc path. Drop the flag to fall back to tsc (typescript stays a
+// devDependency: svelte-check requires it regardless).
 if (argv.includes("--check")) {
-  const r = Bun.spawnSync(["bunx", "svelte-check", "--tsconfig", "./tsconfig.json"], {
-    cwd: import.meta.dir,
-    stdout: "inherit",
-    stderr: "inherit",
-  });
+  const r = Bun.spawnSync(
+    ["bunx", "svelte-check", "--tsconfig", "./tsconfig.json", "--tsgo-experimental-api"],
+    {
+      cwd: import.meta.dir,
+      stdout: "inherit",
+      stderr: "inherit",
+    },
+  );
   process.exit(r.exitCode ?? 1);
 }
 

--- a/knowledge/log.md
+++ b/knowledge/log.md
@@ -35,6 +35,18 @@
   `display.date-format`; pre-stats embeds render the modal without the
   table. 7 new tests (296 total).
 
+- **Update** — [okf](packages/okf.md): `okf viz --check` typechecks on tsgo
+  (`@typescript/native-preview` devDependency) via svelte-check's
+  `--tsgo-experimental-api` — ~2x faster than the tsc path, in-process and
+  artifact-free, so the check now also works from the nix-built package
+  (the tsc path wrote into read-only `node_modules`). `typescript` stays
+  (svelte-check requires it); svelte-check 4.7.1's non-API `--tsgo` flag is
+  silently broken upstream (spawns a `bin/tsgo.js` that native-preview no
+  longer ships, parses the MODULE_NOT_FOUND stderr as zero diagnostics,
+  exits 0). node_modules FOD grows ~180M (7 platform tsgo binaries under
+  `--cpu/--os="*"`); hash refreshed. Plain-TS iteration:
+  `bunx tsgo --noEmit -p tsconfig.json` (~0.2s vs tsc's ~1.2s).
+
 - **Update** — [okf](packages/okf.md): post-review fixes on the
   generalization PR. Three bugs: collect-tier `output` templates now
   reject `{repo}`/`{description}`/`{description-sentence}` at config load

--- a/knowledge/okf-profile.md
+++ b/knowledge/okf-profile.md
@@ -100,7 +100,7 @@ the dev shell (`nix develop` / direnv) it's on `PATH` as **`okf`** via the
 okf scaffold [--force]   # run this repo's scaffolder (scripts/okf-scaffold.ts via okf.toml [scaffold]; idempotent; --force overwrites)
 okf index               # regenerate index.md listings
 okf validate [--strict]  # spec + profile conformance; --strict fails on warnings too
-okf viz [--check|--perf] # render knowledge/viz.html (Svelte 5 viewer); --check runs svelte-check, --perf measures startup in headless Chrome
+okf viz [--check|--perf] # render knowledge/viz.html (Svelte 5 viewer); --check runs svelte-check on tsgo, --perf measures startup in headless Chrome
 okf help [command]      # full usage, per-command flags, docs pointers
 
 bun flakes/okf/okf.ts <cmd>   # equivalent, no dev shell needed

--- a/knowledge/svelte-language.md
+++ b/knowledge/svelte-language.md
@@ -17,7 +17,7 @@ reactivity with **runes** (`$state`, `$derived`, `$effect`).
 graph viewer — rebuilt in Svelte 5 from a vanilla-TS canvas prototype (see
 the [viz-svelte-rebuild decision](decisions/viz-svelte-rebuild.md)). It is
 bundled at CLI runtime by `Bun.build` + bun-plugin-svelte
-([Bun runtime](bun-runtime.md)), typechecked by svelte-check
+([Bun runtime](bun-runtime.md)), typechecked by svelte-check on tsgo
 (`okf viz --check`), and tested under `bun test`.
 
 **The house Svelte knowledge lives in

--- a/knowledge/typescript-language.md
+++ b/knowledge/typescript-language.md
@@ -20,7 +20,11 @@ scripts), and [ccglass](packages/ccglass.md)'s patched upstream are all TS.
 
 **There is no tsc build step anywhere** — bun transpiles on execution, so
 types are documentation-plus-editor-tooling by default. Typechecking is
-opt-in and targeted: `okf viz --check` runs svelte-check over the viewer.
+opt-in and targeted: `okf viz --check` runs svelte-check with TS
+diagnostics from tsgo (`@typescript/native-preview`, the native Go
+compiler) via its experimental API; for plain-TS iteration
+`bunx tsgo --noEmit -p tsconfig.json` in `flakes/okf/` checks everything
+but `.svelte` files in ~0.2s.
 
 **Editor tooling** splits by file type ([nvim LSP](nvim/lsp.md)): vtsls
 serves plain `.ts`/`.tsx` (workspace TypeScript SDK, inlay hints) while the


### PR DESCRIPTION
## What changed

`okf viz --check` now gets its TypeScript diagnostics from **tsgo** (`@typescript/native-preview`, the native Go compiler) through svelte-check's `--tsgo-experimental-api`, instead of tsc.

- `flakes/okf/viz.ts` — the `--check` spawn passes `--tsgo-experimental-api`
- `flakes/okf/package.json` / `bun.lock` — `@typescript/native-preview` added as a devDependency (`typescript` stays: svelte-check requires it regardless)
- `flakes/okf/package.nix` — FOD hash refreshed; comment updated now that the lock contains os/cpu-conditional packages
- `flakes/okf/README.md` — dev-tooling section updated, upstream gotcha documented
- `knowledge/` — log entry + typescript/svelte/okf-profile references updated; `okf validate` clean

## Why

- `okf viz --check`: **1.96s → 0.95s** (~2×)
- Plain-TS iteration: `bunx tsgo --noEmit -p tsconfig.json` runs in **~0.2s vs tsc's ~1.2s** (~7×) with byte-identical file coverage (verified via `--listFilesOnly` diff) and identical diagnostics on injected errors
- The experimental-API mode runs tsgo in-process — no `node` spawn (bun-first repo) and no disk artifacts, so the check now **works from the nix-built package** too; the tsc path wrote `node_modules/.svelte2tsx-language-server-files`, impossible on a read-only store path

## Reviewer notes

**Why not svelte-check's stable `--tsgo` flag:** it is silently broken in 4.7.1 (and on language-tools master) — it spawns `<pkg>/bin/tsgo.js`, a path current native-preview builds no longer ship, then parses the MODULE_NOT_FOUND stderr as zero diagnostics and **exits 0 without checking anything**. The experimental-API path was error-tested instead: injected type errors in both a `.ts` and a `.svelte` file are reported at correct positions with exit 1. Worth an upstream report to sveltejs/language-tools.

**Cost:** the node_modules FOD grows ~180M (331M total) — native-preview ships a ~26M tsgo binary per platform and the existing `--cpu/--os="*"` single-hash design installs all seven.

**Caveats:** the experimental API is flagged "might break without warning" upstream, and the linux tsgo binaries are unverified on nebula (Go-static, expected fine).

**Verification** (rebased on main incl. About modal + the #29 fileset split): `nix flake check ./flakes/okf` green — full suite incl. gitProvider tests, 0 fail; freshly built store package ships `AboutModal.svelte`, no test files, and its `okf viz --check` passes (12 files, 0 errors, exit 0); root flake re-locks the relative-path input and builds; `okf validate` exits 0.