### PR TITLE
okf: keep test files out of the store output; run git tests in the check

### DIFF
--- a/flakes/okf/package.nix
+++ b/flakes/okf/package.nix
@@ -15,28 +15,44 @@
 let
   # Explicit include-list: nix plumbing stays out (nix-only edits don't rebuild
   # the package) and node_modules can never leak in however the source reaches us.
+  sources = lib.fileset.unions [
+    ./okf.ts
+    ./init.ts
+    ./lib.ts
+    ./config-cli.ts
+    ./vcs
+    ./scaffold.ts
+    ./scaffold-api.ts
+    ./index-gen.ts
+    ./validate.ts
+    ./viz.ts
+    ./viz-perf.ts
+    ./layout3d.ts
+    ./tsconfig.json
+    ./package.json
+    ./bun.lock
+    ./bunfig.toml
+    ./viz-app
+    ./test
+  ];
+
+  # Tests stay out of the shipped package: bun's test scanner follows the
+  # `result` symlink `nix build` leaves in the flake root, so any *.test.ts
+  # under $out would run as a stale second copy of the suite.
   src = lib.fileset.toSource {
     root = ./.;
-    fileset = lib.fileset.unions [
-      ./okf.ts
-      ./init.ts
-      ./lib.ts
-      ./config-cli.ts
-      ./vcs
-      ./scaffold.ts
-      ./scaffold-api.ts
-      ./index-gen.ts
-      ./validate.ts
-      ./viz.ts
-      ./viz-perf.ts
-      ./layout3d.ts
-      ./tsconfig.json
-      ./package.json
-      ./bun.lock
-      ./bunfig.toml
-      ./viz-app
-      ./test
-    ];
+    fileset = lib.fileset.difference sources (
+      lib.fileset.unions [
+        ./test
+        (lib.fileset.fileFilter (file: lib.hasSuffix ".test.ts" file.name) ./viz-app)
+      ]
+    );
+  };
+
+  # Full tree including the tests — only checks.test builds from this.
+  testSrc = lib.fileset.toSource {
+    root = ./.;
+    fileset = sources;
   };
 
   # The lock is pure JS — no os/cpu-conditional packages, no install scripts —
@@ -120,10 +136,15 @@ stdenvNoCC.mkDerivation {
   passthru = {
     inherit node_modules;
     # `bun test` offline against the vendored deps; surfaced as checks.test.
+    # git matches the runtime wrapper's PATH and lets the gitProvider tests
+    # run instead of skipIf-skipping.
     tests.unit = stdenvNoCC.mkDerivation {
       name = "okf-tests";
-      inherit src;
-      nativeBuildInputs = [ bun ];
+      src = testSrc;
+      nativeBuildInputs = [
+        bun
+        git
+      ];
       dontConfigure = true;
       buildPhase = ''
         runHook preBuild

--- a/flakes/okf/test/vcs.test.ts
+++ b/flakes/okf/test/vcs.test.ts
@@ -1,7 +1,7 @@
 // VCS provider unit tests: pure remote-URL normalization, the filesystem
 // ("none") provider against tempdir fixtures, and provider auto-selection.
-// Git-dependent cases skip when no git binary is available (the nix check
-// sandbox has bun only).
+// The nix check sandbox provides git (matching the runtime wrapper's PATH);
+// skipIf(!hasGit) only guards against ad-hoc git-less environments.
 
 import { describe, expect, test } from "bun:test";
 import { spawnSync } from "node:child_process";

--- a/knowledge/log.md
+++ b/knowledge/log.md
@@ -1,5 +1,18 @@
 # Log
 
+## 2026-07-05
+
+- **Update** — [okf](packages/okf.md): the nix package no longer ships the
+  test suite (`test/` and `viz-app/*.test.ts` excluded from the runtime
+  fileset; a separate full-tree fileset feeds `checks.test`) — bun's test
+  scanner follows the `result` symlink `nix build` leaves in the flake
+  root, so `bun test` ran a stale store copy of the whole suite alongside
+  the local one (24 files instead of 12, doubled counts). The check
+  sandbox also gains git, matching the runtime wrapper's PATH: the
+  gitProvider tests (evil-merge dating, auto-selection) now run there
+  instead of skipIf-skipping, and the one unguarded git-dependent test
+  (explicit-git error message) no longer fails git-less.
+
 ## 2026-07-04
 
 - **Update** — [okf](packages/okf.md): post-review fixes on the

--- a/knowledge/packages/okf.md
+++ b/knowledge/packages/okf.md
@@ -4,7 +4,7 @@ title: okf
 description: okf — CLI for maintaining OKF knowledge bundles (scaffold/index/validate/viz).
 resource: flakes/okf/
 tags: [sub-flake, package]
-timestamp: '2026-07-04T23:17:27+00:00'
+timestamp: '2026-07-05T06:34:41+00:00'
 ---
 
 okf — CLI for maintaining OKF knowledge bundles (scaffold/index/validate/viz).
@@ -22,6 +22,14 @@ Consumed by the root flake as a relative-path input — see the
   procedure in the README) + a `bun run --no-install` wrapper. The workspace
   it operates on is discovered from the caller's cwd (nearest `okf.toml`,
   else the git toplevel), so the same binary serves any consuming repo.
+
+The store output deliberately excludes the test suite (`test/`,
+`viz-app/*.test.ts`): bun's test scanner follows the `result` symlink that
+`nix build` leaves in the flake root, so a shipped suite would run as a
+stale second copy alongside the working tree's (`bun test` reported 24
+files instead of 12). `checks.<system>.test` builds from a separate
+full-tree fileset with git in the sandbox, so the gitProvider tests
+(evil-merge dating, auto-selection) run there instead of skipIf-skipping.
 
 okf is generic (the [okf-toml-unified-config](../decisions/okf-toml-unified-config.md)
 arc); this repo's scaffolding logic lives outside the flake in


### PR DESCRIPTION
## What changed

- **`flakes/okf/package.nix`**: split the source fileset. The runtime package (`$out/lib/okf`) now excludes `test/` and `viz-app/*.test.ts`; a separate full-tree `testSrc` feeds the `tests.unit` check derivation, so `checks.<system>.test` still runs the complete suite.
- **`package.nix` (check)**: added `git` to the test derivation's `nativeBuildInputs`, matching the runtime wrapper's PATH.
- **`test/vcs.test.ts`**: updated the stale header comment ("the nix check sandbox has bun only").
- **`knowledge/`**: recorded the gotcha in `packages/okf.md` and appended a `log.md` entry; `okf index` + `okf validate` pass.

## Why

`bun test` from `flakes/okf` was running the local suite **plus** a stale copy from the nix store: bun's test scanner follows the `result` symlink `nix build` leaves in the flake root, and the store output shipped its own `*.test.ts` files. Symptom: "Ran 578 tests across 24 files" with `/nix/store/...-okf-0.1.0/lib/okf/...` paths — stale store tests could mask or duplicate failures and skew counts recorded in `knowledge/log.md`.

Separately (pre-existing, surfaced while verifying): `nix flake check` was already failing — the unguarded assertion at `test/vcs.test.ts:142` expects the "not inside a git repository" error, but the git-less sandbox produced "git is not installed" instead. Providing git fixes that and un-skips the two `skipIf(!hasGit)` gitProvider tests (evil-merge dating — the subject of recent commits — and auto-selection), which previously never ran in CI.

## Verification

- Reproduced first: with `result` present, `bun test` ran 578 tests / 24 files; after the fix, 289 / 12 (local only)
- `find result/lib/okf -name '*.test.ts'` → empty; `./result/bin/okf --help` works
- `nix flake check` in `flakes/okf` passes; check log shows **289 pass, 0 fail, 0 skip**
- Root flake still builds `.#okf`; `nix fmt` no-op; statix/deadnix clean
- `okf validate`: 160 files checked, 0 errors