### PR TITLE
Adopt the okflight rebrand: okflight.toml + knowledge/_okflight/scripts/

### DIFF
--- a/.claude/skills/knowledge-bundle/SKILL.md
+++ b/.claude/skills/knowledge-bundle/SKILL.md
@@ -25,11 +25,11 @@ okf viz      # regenerate knowledge/viz.html interactive graph (gitignored; Svel
 
 The okf CLI itself is generic; THIS repo's scaffolding logic (module
 classes, twins, gating, hosts, nvim plugins) lives in
-`knowledge/_okf-scaffold/` — a `main.ts` entry plus one pass file per
+`knowledge/_okflight/scripts/` — a `main.ts` entry plus one pass file per
 scaffolded type (`modules.ts`, `hosts.ts`, `packages.ts`, `nvim.ts`) over a
-shared `lib.ts` — wired via `okf.toml [scaffold] script` and run through
+shared `lib.ts` — wired via `okflight.toml [scaffold] script` and run through
 the injected `ScaffoldContext` API (vendored type surface:
-`knowledge/_okf-scaffold/okf-scaffold-api.d.ts`; the runtime is injected by
+`knowledge/_okflight/scripts/scaffold-api.d.ts`; the runtime is injected by
 `okf scaffold`, so no okf checkout is needed).
 Component-scan changes (new source dirs, new doc types, cross-link targets)
 are edits to the matching pass file, not to okf itself. The `_` prefix

--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -12,7 +12,7 @@ on:
     paths:
       - "knowledge/**"
       - "flake.lock" # okf bumps arrive as lock updates (github:kriswill/okflight)
-      - "okf.toml"
+      - "okflight.toml"
       - ".github/workflows/pages.yml"
   workflow_dispatch:
 

--- a/flake.lock
+++ b/flake.lock
@@ -1002,11 +1002,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1783284665,
-        "narHash": "sha256-SwL2bVby+JCOJmjL/IHpfcWKswhzoOl5izUlfAwVWvE=",
+        "lastModified": 1783296211,
+        "narHash": "sha256-/wMDd8apCYg4txBcN9PLGNCZ0yLOPgo2Phv3Zuvgj0g=",
         "ref": "refs/heads/main",
-        "rev": "7dbd00951b3d214f2832624396600491f0465f94",
-        "revCount": 19,
+        "rev": "f318be0ba0e8345536907941938b8bca04fbdd0b",
+        "revCount": 38,
         "type": "git",
         "url": "ssh://git@github.com/kriswill/okflight.git"
       },

--- a/knowledge/_okflight/scripts/hosts.ts
+++ b/knowledge/_okflight/scripts/hosts.ts
@@ -7,7 +7,7 @@
 // host-specific file; `moduleNames` comes from the modules pass (enable-flag
 // filter + doc-slug collision check).
 
-import type { ScaffoldContext } from "./okf-scaffold-api";
+import type { ScaffoldContext } from "./scaffold-api";
 import { classTag, docType, type ClassName, type Repo } from "./lib";
 
 export function scaffoldHosts(

--- a/knowledge/_okflight/scripts/lib.ts
+++ b/knowledge/_okflight/scripts/lib.ts
@@ -2,11 +2,11 @@
 // packages.ts, nvim.ts): repo file access rooted at ctx.root, plus the
 // darwin/nixos class constants the module and host passes both speak.
 // Everything else each pass needs comes from the injected ScaffoldContext
-// (okf-scaffold-api.d.ts, vendored from okflight).
+// (scaffold-api.d.ts, vendored from okflight).
 
 import { readdirSync, readFileSync, statSync, type Stats } from "node:fs";
 import { join } from "node:path";
-import type { ScaffoldContext } from "./okf-scaffold-api";
+import type { ScaffoldContext } from "./scaffold-api";
 
 export const CLASSES = ["darwin", "nixos"] as const;
 export type ClassName = (typeof CLASSES)[number];

--- a/knowledge/_okflight/scripts/main.ts
+++ b/knowledge/_okflight/scripts/main.ts
@@ -1,5 +1,5 @@
 // This repo's okf scaffolder — the dotfiles-specific metadata pass, invoked
-// by `okf scaffold` via okf.toml `[scaffold] script`. One pass per scaffolded
+// by `okf scaffold` via okflight.toml `[scaffold] script`. One pass per scaffolded
 // type, each in its own file beside this entry:
 //   modules.ts   — feature modules (darwin/nixos twins) + flake-parts plumbing
 //   hosts.ts     — host registrations + host-specific files
@@ -9,11 +9,11 @@
 // Idempotence, --force, and the written/skipped summary are owned by the
 // injected ctx.emit (okflight's scaffold-api.ts); these passes use only the
 // injected API plus node builtins — no runtime import from the okf checkout.
-// Lives in knowledge/_okf-scaffold/ (bundle-adjacent tooling): the `_` prefix
+// Lives in knowledge/_okflight/scripts/ (bundle-adjacent tooling): the `_` prefix
 // keeps the directory invisible to okf's walkMd/index-gen, so the bundle
 // itself stays pure markdown and OKF-conformant.
 
-import type { ScaffoldContext } from "./okf-scaffold-api";
+import type { ScaffoldContext } from "./scaffold-api";
 import { scaffoldHosts } from "./hosts";
 import { repoOf } from "./lib";
 import { scaffoldModules } from "./modules";

--- a/knowledge/_okflight/scripts/modules.ts
+++ b/knowledge/_okflight/scripts/modules.ts
@@ -4,7 +4,7 @@
 // implementations. Returns the full module-name set — the hosts pass filters
 // enable flags against it and host-qualifies doc slugs that would collide.
 
-import type { ScaffoldContext } from "./okf-scaffold-api";
+import type { ScaffoldContext } from "./scaffold-api";
 import {
   CLASS_LABEL,
   CLASSES,

--- a/knowledge/_okflight/scripts/nvim.ts
+++ b/knowledge/_okflight/scripts/nvim.ts
@@ -2,7 +2,7 @@
 // Each spec file under lua/plugins/ (or dir with init.lua) is one plugin,
 // dispatched by lua/config/pack.lua — see knowledge/nvim/architecture.md.
 
-import type { ScaffoldContext } from "./okf-scaffold-api";
+import type { ScaffoldContext } from "./scaffold-api";
 import type { Repo } from "./lib";
 
 export function scaffoldNvim(ctx: ScaffoldContext, repo: Repo): void {

--- a/knowledge/_okflight/scripts/packages.ts
+++ b/knowledge/_okflight/scripts/packages.ts
@@ -1,7 +1,7 @@
 // Scaffold pass: custom packages (pkgs/), overlay-only entries (no pkgs/
 // counterpart), and sub-flakes (flakes/) -> knowledge/packages/<name>.md.
 
-import type { ScaffoldContext } from "./okf-scaffold-api";
+import type { ScaffoldContext } from "./scaffold-api";
 import type { Repo } from "./lib";
 
 export function scaffoldPackages(ctx: ScaffoldContext, repo: Repo): void {

--- a/knowledge/_okflight/scripts/scaffold-api.d.ts
+++ b/knowledge/_okflight/scripts/scaffold-api.d.ts
@@ -1,26 +1,35 @@
 // Vendored type surface of okf's ScaffoldContext (scaffold-api.ts in
 // github:kriswill/okflight). The real implementation is INJECTED at runtime —
 // `okf scaffold` dynamically imports main.ts and calls its default export
-// with a live context, so these passes need no runtime import from the okf
-// checkout; this file exists purely for editor/type support (bun erases
-// type-only imports). Refresh it against okflight's scaffold-api.ts when
-// okf's API changes; members the passes don't use are typed loosely on
+// with a live context, so scaffold passes need no runtime import from an
+// okflight checkout; this file exists purely for editor/type support (bun
+// erases type-only imports). Refresh it against okflight's scaffold-api.ts
+// when okf's API changes; members passes rarely need are typed loosely on
 // purpose — widen them here if a pass starts needing one.
 
 /** Frontmatter map handed to emit()/fmToYaml(). */
 export type FM = Record<string, unknown>;
+
+/** The VCS surface scaffold passes typically need — okf's full VcsProvider
+ *  (vcs/types.ts) is what's actually injected. */
+export interface ScaffoldVcs {
+  /** All tracked file paths, root-relative, sorted. */
+  trackedFiles(): string[];
+  /** ISO-8601 last-modified of a root-relative path, or null (prefer
+   *  ctx.timestamp, which adds the now-fallback). */
+  lastModified(path: string): string | null;
+}
 
 export interface ScaffoldContext {
   /** Absolute workspace root. */
   root: string;
   /** Absolute bundle root. */
   bundle: string;
-  /** Workspace-relative bundle dir (cfg.viz.bundle.dir). */
+  /** Workspace-relative bundle dir. */
   bundleDir: string;
-  /** Full okf.toml config — opaque here; see okflight's config-cli.ts. */
+  /** Full okflight.toml config — opaque here; see okflight's config-cli.ts. */
   config: unknown;
-  /** VCS adapter — opaque here; see okflight's vcs/. */
-  vcs: unknown;
+  vcs: ScaffoldVcs;
   /** --force was passed: existing docs are overwritten. */
   force: boolean;
 
@@ -49,7 +58,11 @@ export interface ScaffoldContext {
   mdSafe(s: string): string;
   titleFromSlug(slug: string): string;
   fmToYaml(fm: FM): string;
-  parseFrontmatter(raw: string): unknown;
+  parseFrontmatter(raw: string): {
+    fm: Record<string, string | string[]> | null;
+    fmError: string | null;
+    body: string;
+  };
   nowISO(): string;
   log(msg: string): void;
 

--- a/knowledge/decisions/okf-scaffold-hook.md
+++ b/knowledge/decisions/okf-scaffold-hook.md
@@ -9,7 +9,7 @@ timestamp: '2026-07-04T00:00:00-07:00'
 **Status:** active. **Where:**
 [`scaffold-api.ts`](https://github.com/kriswill/okflight/blob/main/scaffold-api.ts)
 (injected API), [`scaffold.ts`](https://github.com/kriswill/okflight/blob/main/scaffold.ts)
-(generic driver), [../_okf-scaffold/main.ts](../_okf-scaffold/main.ts)
+(generic driver), [../_okflight/scripts/main.ts](../_okflight/scripts/main.ts)
 (this repo's pass — since split per type and moved bundle-adjacent, see
 [okf-scaffold-split](okf-scaffold-split.md)). Part of the okf generalization
 arc ([okf-toml-unified-config](okf-toml-unified-config.md)).

--- a/knowledge/decisions/okf-scaffold-split.md
+++ b/knowledge/decisions/okf-scaffold-split.md
@@ -7,8 +7,8 @@ timestamp: '2026-07-05T00:00:00-07:00'
 ---
 
 **Status:** active. **Where:**
-[../_okf-scaffold/main.ts](../_okf-scaffold/main.ts) (entry),
-[../_okf-scaffold/lib.ts](../_okf-scaffold/lib.ts) (shared repo access +
+[../_okflight/scripts/main.ts](../_okflight/scripts/main.ts) (entry),
+[../_okflight/scripts/lib.ts](../_okflight/scripts/lib.ts) (shared repo access +
 class vocabulary). Follows on from
 [okf-scaffold-hook](okf-scaffold-hook.md), which moved the pass out of the
 okf flake in the first place.

--- a/knowledge/decisions/okf-toml-unified-config.md
+++ b/knowledge/decisions/okf-toml-unified-config.md
@@ -8,7 +8,7 @@ timestamp: '2026-07-04T00:00:00-07:00'
 
 **Status:** active. **Where:**
 [`config-cli.ts`](https://github.com/kriswill/okflight/blob/main/config-cli.ts) (loader),
-[../../okf.toml](../../okf.toml) (this repo's config). Extends
+[../../okflight.toml](../../okflight.toml) (this repo's config). Extends
 [viz-config-toml](viz-config-toml.md).
 
 ## Context

--- a/knowledge/decisions/viz-config-toml.md
+++ b/knowledge/decisions/viz-config-toml.md
@@ -12,7 +12,7 @@ timestamp: '2026-07-04T00:00:00-07:00'
 [okf-facet-classify](okf-facet-classify.md) — the `nix-packages` facet
 source described below is now the `classify` union (legacy spelling still
 accepted).
-**Where:** [../../okf.toml](../../okf.toml), viewer schema in
+**Where:** [../../okflight.toml](../../okflight.toml), viewer schema in
 [`viz-app/config.ts`](https://github.com/kriswill/okflight/blob/main/viz-app/config.ts),
 loaded by [`config-cli.ts`](https://github.com/kriswill/okflight/blob/main/config-cli.ts).
 `okf-viz.toml` below is the file's original name (historical prose).

--- a/knowledge/log.md
+++ b/knowledge/log.md
@@ -2,6 +2,18 @@
 
 ## 2026-07-05
 
+- **Update** — okflight's rebrand adopted repo-side: `okf.toml` renamed to
+  `okflight.toml` (upstream okf discovers both; new name wins) and the
+  scaffold passes moved `knowledge/_okf-scaffold/` →
+  `knowledge/_okflight/scripts/`, matching the layout `okf setup` now
+  scaffolds everywhere. The vendored type surface refreshed from okflight's
+  published template as `scaffold-api.d.ts` (types `ctx.vcs` as a minimal
+  `ScaffoldVcs` instead of `unknown`). Current-state docs updated
+  ([okf-profile](okf-profile.md), [okf](packages/okf.md), the
+  knowledge-bundle skill); decision records keep their historical prose,
+  with Where-links repointed at the new paths. The `okf` input advanced
+  past the rename (okflight now also on npm as `@kriswill/okflight`).
+
 - **Decision** — [okflight-extraction](decisions/okflight-extraction.md):
   okf promoted out of `flakes/okf/` into its own private repository,
   [kriswill/okflight](https://github.com/kriswill/okflight), via

--- a/knowledge/okf-profile.md
+++ b/knowledge/okf-profile.md
@@ -12,9 +12,9 @@ tooling disagree, we pick one and record it here.
 
 ## Profile rules
 
-These rules are enforced from `okf.toml`'s `[profile]` section (okf's
+These rules are enforced from `okflight.toml`'s `[profile]` section (okf's
 built-in defaults reproduce exactly the rules below — this repo's
-`okf.toml` therefore sets nothing; another bundle can tune
+`okflight.toml` therefore sets nothing; another bundle can tune
 `required-fields`/`recommended-fields`/`reserved-files`/`rooted-links`/
 `repo-links` without touching okf).
 
@@ -96,17 +96,17 @@ the `okf` flake input, re-exported as `packages.<system>.okf`, and advanced
 with `nix flake update okf`
 ([okflight-extraction](decisions/okflight-extraction.md)). This repo's
 scaffold passes live bundle-adjacent in
-[`knowledge/_okf-scaffold/`](_okf-scaffold/main.ts) — the `_` prefix hides
+[`knowledge/_okflight/scripts/`](_okflight/scripts/main.ts) — the `_` prefix hides
 them from okf's walkers, so the bundle itself stays pure markdown
 ([okf-scaffold-split](decisions/okf-scaffold-split.md)); their type-only
 `ScaffoldContext` import is satisfied by the vendored
-[`okf-scaffold-api.d.ts`](_okf-scaffold/okf-scaffold-api.d.ts) (the runtime
+[`scaffold-api.d.ts`](_okflight/scripts/scaffold-api.d.ts) (the runtime
 API is injected by `okf scaffold`, so no okf checkout is needed). In the dev
 shell (`nix develop` / direnv) the nix-built CLI is on `PATH` as **`okf`**
 via the [dev](modules/dev.md) module:
 
 ```sh
-okf scaffold [--force]   # run this repo's scaffolder (knowledge/_okf-scaffold/main.ts via okf.toml [scaffold]; idempotent; --force overwrites)
+okf scaffold [--force]   # run this repo's scaffolder (knowledge/_okflight/scripts/main.ts via okflight.toml [scaffold]; idempotent; --force overwrites)
 okf index               # regenerate index.md listings
 okf validate [--strict]  # spec + profile conformance; --strict fails on warnings too
 okf viz                 # render knowledge/viz.html (Svelte 5 viewer)
@@ -126,7 +126,7 @@ okf's `node_modules`, which is a read-only store path in the packaged CLI.
 okflight checkout). Repo-specific strings and settings (header,
 facet filters (0..n `[facet.<name>]` lenses), type taxonomy, legend groups,
 embed cap, bundle dir) come from the optional repo-root
-[`okf.toml`](../okf.toml) — one config file read by **all** okf commands
+[`okflight.toml`](../okflight.toml) — one config file read by **all** okf commands
 (loaded by okf's `config-cli.ts`, strict-validated; a malformed file
 fails every command); without it okf works with generic fallbacks (see the
 [viz-config-toml](decisions/viz-config-toml.md) and

--- a/knowledge/packages/okf.md
+++ b/knowledge/packages/okf.md
@@ -30,7 +30,7 @@ Consumption after the extraction:
   `node_modules` (fixed-output `bun install` keyed on `bun.lock` — refresh
   procedure in okflight's README) + a `bun run --no-install` wrapper. The
   workspace it operates on is discovered from the caller's cwd (nearest
-  `okf.toml`, else the git toplevel), so the same binary serves any
+  `okflight.toml`, else the git toplevel), so the same binary serves any
   consuming repo.
 - **GitHub Pages CI** (`.github/workflows/pages.yml`) builds `viz.html`
   bun-natively — no nix on CI — checking out okflight at the
@@ -47,15 +47,15 @@ dating, auto-selection) run there instead of skipIf-skipping.
 
 okf is generic (the [okf-toml-unified-config](../decisions/okf-toml-unified-config.md)
 arc); this repo's scaffolding logic lives in
-[`knowledge/_okf-scaffold/`](../_okf-scaffold/main.ts) — one pass file per
+[`knowledge/_okflight/scripts/`](../_okflight/scripts/main.ts) — one pass file per
 scaffolded type (`modules.ts`, `hosts.ts`, `packages.ts`, `nvim.ts`) behind
 a `main.ts` entry — dynamically imported by `okf scaffold` per
-`okf.toml [scaffold] script` and driven through the injected
+`okflight.toml [scaffold] script` and driven through the injected
 `ScaffoldContext` API
 ([okf-scaffold-hook](../decisions/okf-scaffold-hook.md),
 [okf-scaffold-split](../decisions/okf-scaffold-split.md)). The passes'
 type-only import is satisfied by the vendored
-[`okf-scaffold-api.d.ts`](../_okf-scaffold/okf-scaffold-api.d.ts).
+[`scaffold-api.d.ts`](../_okflight/scripts/scaffold-api.d.ts).
 
 No `bun build --compile`: `okf viz` bundles the
 [Svelte](../svelte-language.md) viewer with `Bun.build`

--- a/okflight.toml
+++ b/okflight.toml
@@ -1,4 +1,4 @@
-# okf.toml — repo-specific settings for the okf CLI (all commands; loaded by
+# okflight.toml — repo-specific settings for the okf CLI (all commands; loaded by
 # okf's config-cli.ts, viewer schema in viz-app/config.ts — github:kriswill/okflight).
 # Without this file okf still works with generic fallbacks: knowledge/ bundle
 # dir, no facet filters, alphabetical types with generated colors, flat
@@ -9,7 +9,7 @@ dir = "knowledge" # OKF bundle root, repo-relative
 out = "viz.html"  # output file, relative to the bundle dir
 
 [scaffold]
-script = "knowledge/_okf-scaffold/main.ts" # repo-owned metadata pass, run by `okf scaffold`; `_` keeps it out of the bundle walk
+script = "knowledge/_okflight/scripts/main.ts" # repo-owned metadata pass, run by `okf scaffold`; `_` keeps it out of the bundle walk
 # command = ["python3", "tools/scaffold.py"]  # non-JS alternative (OKF_* env); exclusive with script
 # [[scaffold.collect]]                        # declarative tier for simple cases (glob + templates)
 # glob = "src/services/*.py"


### PR DESCRIPTION
Follows upstream okflight's rename (config `okf.toml` → `okflight.toml`, scaffold passes `knowledge/_okf-scaffold/` → `knowledge/_okflight/scripts/`, vendored d.ts refreshed from the published template). Current-state docs updated; decision records keep historical prose with links repointed. `okf` input advanced to f318be0 (also drives pages CI); pages.yml trigger path follows. Verified: validate 162 files clean, scaffold no-ops from the new location, index byte-identical, nix-built pinned okf agrees.