### PR TITLE
darwin(claude-account-selector): symlink ~/.claude to a fallback profile

### DIFF
--- a/knowledge/decisions/claude-profile-isolation.md
+++ b/knowledge/decisions/claude-profile-isolation.md
@@ -36,6 +36,12 @@ login per `CLAUDE_CONFIG_DIR`.
 - A matching `ccglass` function applies the same resolution for the traffic
   inspector, which spawns the real `claude` binary directly and would
   otherwise bypass the wrapper.
+- The LaunchAgent's env can be lost (login race, or a relaunch chain from a
+  var-less instance — seen 2026-06-28 and 2026-07-10, the latter growing a
+  stray parallel config tree in `~/.claude`), so `fallbackProfile` symlinks
+  `~/.claude` → `~/.claude-<profile>` at activation as the backstop.
+  Activation never deletes a real `~/.claude` directory (stray trees hold
+  session data); it warns and waits for a hand migration.
 
 ## Consequences
 
@@ -43,6 +49,9 @@ login per `CLAUDE_CONFIG_DIR`.
 - Stateful subcommands (`claude mcp add`, …) are cwd-scoped to the resolved
   profile — intentional, occasionally surprising.
 - The desktop app gets one fixed profile; ~0.2 s auth probe per launch.
+- With the fallback symlink, env-loss is silent (a work session that misses
+  the env var lands in the personal profile) and the unsegregated `~/.claude`
+  scope effectively ceases to exist.
 
 ## Citations
 

--- a/knowledge/log.md
+++ b/knowledge/log.md
@@ -2,6 +2,17 @@
 
 ## 2026-07-10
 
+- **Update** — [claude-account-selector](modules/claude-account-selector.md) /
+  [claude-profile-isolation](decisions/claude-profile-isolation.md): new
+  `fallbackProfile` option symlinks `~/.claude` → `~/.claude-<profile>` at
+  activation (order 1601), closing the env-loss hole where a desktop launch
+  that misses the LaunchAgent's `CLAUDE_CONFIG_DIR` (login race / var-less
+  relaunch chain, seen 2026-06-28 and 2026-07-10) silently grows a stray
+  config tree in `~/.claude`. Activation never deletes a real `~/.claude`
+  directory — it warns and waits for a hand migration. Host `k` sets
+  `fallbackProfile = "me"`. Trade-off recorded: env-loss is now silent, and
+  a work session that misses the env var lands in the personal profile.
+
 - **Creation** — [helium-chrome-shim](modules/helium-chrome-shim.md) /
   [decision](decisions/helium-chrome-shim.md): dropped the chromium cask from
   [homebrew](modules/homebrew.md) (Helium is the browser now), which broke

--- a/modules/darwin/claude-account-selector/README.md
+++ b/modules/darwin/claude-account-selector/README.md
@@ -66,7 +66,8 @@ run against the **resolved profile's** config dir, so their effect is cwd-depend
 `claude mcp add` under `~/src/perforce/...` edits `~/.claude-work`; the same command elsewhere
 edits `~/.claude-me`. This is intentional (profiles are isolated), but it means servers/config
 in your original `~/.claude` aren't visible under a profile unless you seeded that profile
-from it (see setup). Use `command claude …` to operate on the original `~/.claude`.
+from it (see setup). Use `command claude …` to operate on the original `~/.claude` — though
+with `fallbackProfile` set, `~/.claude` is itself a symlink to that profile's dir.
 
 ## Desktop app (GUI)
 
@@ -86,6 +87,7 @@ programs.claude-account-selector = {
   defaultProfile = "me";
   profiles = [ "me" "work" ];
   desktopProfile = "me";   # GUI desktop app → ~/.claude-me
+  fallbackProfile = "me";  # ~/.claude → ~/.claude-me (env-loss backstop)
 };
 ```
 
@@ -101,12 +103,34 @@ init: an interactive shell that merely **inherited** this exact value drops it, 
 resolves by `$PWD` as usual. An explicit `CLAUDE_CONFIG_DIR=… claude` (set *after* init, per
 command) is unaffected and still wins.
 
+### The env-loss backstop (`fallbackProfile`)
+
+The LaunchAgent's `launchctl setenv` can be **lost**: a login race (agent runs after the
+desktop app launched), or a relaunch chain started from a var-less instance (both seen, on
+2026-06-28 and 2026-07-10). A launch that misses `CLAUDE_CONFIG_DIR` falls back to the
+unsegregated `~/.claude` and silently grows a parallel config tree there — stray sessions,
+memories, and settings that the real profile never sees.
+
+Set `fallbackProfile` to close that hole: activation replaces `~/.claude` with a symlink to
+`~/.claude-<fallbackProfile>`, so env-less launches land in a real profile. Safety rules:
+
+- Activation only **creates or re-points a symlink**. A real `~/.claude` directory is never
+  deleted — activation warns and leaves it. Migrate its contents into the profile dir
+  (sessions/`projects/`, `plans/`, `tasks/`, memories; check for collisions), remove the
+  emptied dir, and re-activate.
+- Trade-off: env-loss becomes **silent** — a *work* session that misses the env var lands in
+  this (typically personal) profile instead of a visibly stray `~/.claude`. The symlink is a
+  default, not per-directory routing.
+- `command claude` (wrapper bypass) and anything else reading `~/.claude` now also resolve to
+  the fallback profile — the "unsegregated scope" effectively ceases to exist.
+
 ### Activation & verification
 
 ```sh
 nrs                                                  # nh darwin switch ~/src/dotfiles
 launchctl setenv CLAUDE_CONFIG_DIR ~/.claude-me      # apply now (or just log out/in)
 launchctl getenv  CLAUDE_CONFIG_DIR                  # → /Users/<you>/.claude-me
+readlink ~/.claude                                   # → /Users/<you>/.claude-me (fallbackProfile set)
 # Cmd-Q and relaunch the Claude desktop app so its next session inherits the env.
 # In a fresh Ghostty window, `echo $CLAUDE_CONFIG_DIR` should be EMPTY (scrub working).
 ```
@@ -186,6 +210,7 @@ zsh file with built-in fallbacks, so it also runs standalone (e.g. under test).
 | `profiles` | list of str | `[ "me" "work" ]` | Accepted profile names → `~/.claude-<name>` and keychain `claude-token-<name>`. |
 | `rules` | attrs (path → profile) | `{ "<home>/src/work" = "work"; }` | Built-in path-prefix rules; longest match wins. `{ }` for none. |
 | `desktopProfile` | str or null | `null` | Pin the GUI Claude **desktop app** to `~/.claude-<name>` via a login LaunchAgent. See [Desktop app (GUI)](#desktop-app-gui). |
+| `fallbackProfile` | str or null | `null` | Symlink `~/.claude` → `~/.claude-<name>` so launches that miss `CLAUDE_CONFIG_DIR` land in a real profile. See [The env-loss backstop](#the-env-loss-backstop-fallbackprofile). |
 
 ```nix
 # In a host module (modules/hosts/<hostname>/default.nix):

--- a/modules/darwin/claude-account-selector/default.nix
+++ b/modules/darwin/claude-account-selector/default.nix
@@ -108,6 +108,30 @@
             `null` (default) leaves the desktop app on the unsegregated `~/.claude`.
           '';
         };
+
+        fallbackProfile = lib.mkOption {
+          type = lib.types.nullOr lib.types.str;
+          default = null;
+          example = "me";
+          description = ''
+            Replace the unsegregated fallback dir `~/.claude` with a symlink to
+            `~/.claude-<fallbackProfile>`.
+
+            Anything that launches without `CLAUDE_CONFIG_DIR` reads `~/.claude` and
+            silently grows a parallel config tree there. The `desktopProfile` LaunchAgent
+            covers the normal GUI case, but its env can be lost (login race, or a
+            relaunch chain from a var-less instance — seen 2026-06-28 and 2026-07-10);
+            the symlink is the backstop that catches whatever misses the env.
+
+            Activation only creates or re-points the symlink. A real `~/.claude`
+            directory is never deleted — activation warns and leaves it; migrate its
+            contents into the profile dir and remove it, then re-activate.
+
+            Trade-off: env-loss becomes silent — e.g. a *work* session that misses the
+            env var lands in this (typically personal) profile instead of a visibly
+            stray `~/.claude`. `null` (default) manages no symlink.
+          '';
+        };
       };
 
       config = lib.mkIf cfg.enable (
@@ -126,6 +150,27 @@
                 'mkdir -p ${home}/.config/zsh && ln -sfn ${snippet} ${home}/.config/zsh/claude-account-selector.zsh'
             '';
           }
+
+          # Point the unsegregated fallback dir at a real profile: ~/.claude →
+          # ~/.claude-<fallbackProfile>. Order 1601: right after the zsh snippet
+          # link (1600). Never deletes a real ~/.claude directory — a stray tree
+          # holds session data and must be migrated by hand first.
+          (lib.mkIf (cfg.fallbackProfile != null) {
+            system.activationScripts.postActivation.text = lib.mkOrder 1601 ''
+              /usr/bin/sudo -u k --set-home /bin/sh -c '
+                link=${home}/.claude target=${home}/.claude-${cfg.fallbackProfile}
+                if [ -L "$link" ]; then
+                  [ "$(readlink "$link")" = "$target" ] || ln -sfn "$target" "$link"
+                elif [ -e "$link" ]; then
+                  echo "claude-account-selector: $link exists and is not a symlink;" \
+                    "refusing to replace it — migrate its contents into $target," \
+                    "remove it, then re-activate" >&2
+                else
+                  ln -s "$target" "$link"
+                fi
+              '
+            '';
+          })
 
           # Pin the GUI desktop app to ~/.claude-<desktopProfile> by injecting
           # CLAUDE_CONFIG_DIR into the macOS login (Aqua) session at login.

--- a/modules/hosts/k/default.nix
+++ b/modules/hosts/k/default.nix
@@ -48,6 +48,9 @@
       # Pin the GUI Claude desktop app to ~/.claude-me (GUI apps can't do the
       # per-$PWD switching the shell wrapper does). See the module README.
       desktopProfile = "me";
+      # Backstop for launches that miss CLAUDE_CONFIG_DIR entirely (launchd env
+      # lost to a login race / var-less relaunch): ~/.claude → ~/.claude-me.
+      fallbackProfile = "me";
     };
 
     nixpkgs.hostPlatform = "aarch64-darwin";


### PR DESCRIPTION
## What

New `fallbackProfile` option on `programs.claude-account-selector`: activation (order 1601, right after the zsh snippet link) replaces the unsegregated `~/.claude` with a symlink to `~/.claude-<profile>`. Host `k` sets `fallbackProfile = "me"`.

## Why

The `desktopProfile` LaunchAgent's `launchctl setenv` can be lost — a login race, or a relaunch chain started from a var-less instance (seen 2026-06-28 and 2026-07-10). A launch that misses `CLAUDE_CONFIG_DIR` falls back to `~/.claude` and silently grows a parallel config tree there (stray sessions, memories, settings the real profile never sees; the 07-10 incident left a 2.8 MB transcript + memories that had to be hand-migrated). The symlink is the backstop that catches whatever misses the env.

## Safety

- Activation only **creates or re-points a symlink**: correct link → no-op; wrong/broken link → `ln -sfn`; a **real `~/.claude` directory is never deleted** — activation warns and leaves it for hand migration.
- Trade-off (documented in the option, README, and decision record): env-loss becomes silent — a *work* session that misses the env var lands in the personal profile instead of a visibly stray `~/.claude`.

## Verification

- `nix build .#darwinConfigurations.k.system` passes on this branch
- Rendered activation text inspected via `nix eval`; all four script branches (create / no-op / re-point / preserve-and-warn) exercised standalone
- `statix` / `deadnix` clean on the touched nix files; `nix fmt` applied
- `okf validate` — 0 errors, 0 warnings; log + decision record updated per knowledge-bundle conventions

The symlink already exists on `k` (created during the 07-10 incident cleanup), so the first switch after merge hits the no-op branch — nix just owns it from now on.