### PR TITLE
docs+ci: sweep stale Codeberg and okflight-git+ssh claims

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -69,20 +69,5 @@ jobs:
 
       - uses: DeterminateSystems/flakehub-cache-action@main
 
-      # snowglobe-lib lives on codeberg.org, which intermittently serves
-      # 503/504 (observed 2026-07-10, from residential IPs too — not just
-      # datacenter blocking). Fetch all inputs with backoff (~10 min grace)
-      # so the build step never dies on a fetch blip. If Codeberg flakiness
-      # becomes chronic, the escalation is mirroring snowglobe-lib to GitHub
-      # and swapping the input URL.
-      - name: Fetch flake inputs (retried)
-        run: |
-          for i in 1 2 3 4 5; do
-            nix flake archive && exit 0
-            echo "input fetch attempt $i failed (Codeberg down?); retrying in $((i * 60))s" >&2
-            sleep $((i * 60))
-          done
-          exit 1
-
       - name: Build NixOS toplevel (nebula)
         run: nix build .#nixosConfigurations.nebula.config.system.build.toplevel -L

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -6,7 +6,8 @@ Nix-based dotfiles for **macOS (nix-darwin)** and **NixOS** in one flake — no
 home-manager anywhere; every config is a per-class system module + the shared
 GNU Stow tree under `home/`. Hosts: `k`, `mini`, `SOC-Kris-Williams`
 (aarch64-darwin) and `nebula` (x86_64-linux desktop: Hyprland/Noctalia on
-[snowglobe-lib](https://codeberg.org/earthgman/snowglobe-lib)). Primary
+[snowglobe-lib](https://github.com/kriswill/snowglobe-lib) (GitHub fork
+of the Codeberg upstream)). Primary
 configs: Neovim (Lua), Tmux, Zsh, CLI tools; nebula adds the Wayland desktop
 stack. Flake-based, using flake-parts + `import-tree` (the Dendritic pattern):
 every `.nix` file under `modules/` is auto-discovered as a flake-parts module.

--- a/README.md
+++ b/README.md
@@ -4,7 +4,8 @@ One flake for all my machines: three Macs (`k`, `mini`, `SOC-Kris-Williams` —
 [nix-darwin](https://github.com/lnl7/nix-darwin), Apple Silicon) and the
 `nebula` NixOS desktop (AMD/NVIDIA, Wayland: [Hyprland](https://hyprland.org) +
 [Noctalia](https://github.com/noctalia-dev/noctalia-shell), built on
-[snowglobe-lib](https://codeberg.org/earthgman/snowglobe-lib)). Everything is
+[snowglobe-lib](https://github.com/kriswill/snowglobe-lib) (GitHub fork
+of the Codeberg upstream)). Everything is
 organised with the dendritic pattern ([flake-parts](https://flake.parts) +
 [import-tree](https://github.com/vic/import-tree)): per-OS module classes
 (`modules/darwin/`, `modules/nixos/`), a shared GNU Stow tree (`home/`) for the

--- a/knowledge/decisions/ci-github-actions.md
+++ b/knowledge/decisions/ci-github-actions.md
@@ -93,9 +93,11 @@ observation removed the entire hard part.
   precautionary). `nixos-nebula` failed twice on **Codeberg 503/504
   fetching snowglobe-lib** — reproduced from a residential IP, i.e. a real
   Codeberg outage, and only the nebula eval forces that input (darwin
-  never touches Codeberg). Mitigation: a retried `nix flake archive` step
-  (~10 min backoff) before the build; escalation if chronic: mirror
-  snowglobe-lib to GitHub and swap the input URL.
+  never touches Codeberg). Mitigation was a retried `nix flake archive`
+  step (~10 min backoff). **Resolved 2026-07-11:** the escalation happened
+  — snowglobe-lib moved to the `github:kriswill/snowglobe-lib` fork
+  (`16207cf`), every input is now GitHub or FlakeHub, and the retry step
+  was removed.
 
 ## Citations
 

--- a/knowledge/decisions/okflight-extraction.md
+++ b/knowledge/decisions/okflight-extraction.md
@@ -6,7 +6,10 @@ tags: [okf, sub-flake, extraction, okflight]
 timestamp: '2026-07-05T00:00:00-07:00'
 ---
 
-**Status:** active. **Where:** [okf](../packages/okf.md),
+**Status:** active; **2026-07-11 update:** okflight went public — the input
+is now plain `github:kriswill/okflight` and the git+ssh/1Password auth
+mechanics below are historical ([ci-github-actions](ci-github-actions.md)
+records the deploy-key retirement). **Where:** [okf](../packages/okf.md),
 [dev](../modules/dev.md), `flake.nix` (`okf` input),
 `.github/workflows/pages.yml`.
 

--- a/knowledge/log.md
+++ b/knowledge/log.md
@@ -3,6 +3,18 @@
 ## 2026-07-11
 
 - **Update** — [ci-github-actions](decisions/ci-github-actions.md) /
+  [okflight-extraction](decisions/okflight-extraction.md) / `.github/workflows/ci.yml`
+  / AGENTS.md / README.md / [okf](packages/okf.md) / okf-profile: stale-claim
+  sweep after two input moves. snowglobe-lib now comes from the
+  `github:kriswill/snowglobe-lib` fork (`16207cf`) — the Codeberg-5xx retry
+  step left ci.yml (its reason to exist is gone; every input is GitHub or
+  FlakeHub) and the snowglobe links point at the fork. okflight's
+  public-since-2026-07 status corrected everywhere that still described the
+  private git+ssh/1Password fetch as current (append-only log entries and
+  the extraction record's Decision body stay as history; the record got a
+  dated status note instead).
+
+- **Update** — [ci-github-actions](decisions/ci-github-actions.md) /
   `flake.nix` / all three workflows: okf turned out to be PUBLIC (flipped
   with the okflight rebrand), so its input became `github:kriswill/okflight`
   and the deploy-key machinery (`OKFLIGHT_DEPLOY_KEY`, ssh-agent,

--- a/knowledge/okf-profile.md
+++ b/knowledge/okf-profile.md
@@ -90,8 +90,8 @@ Module`, `Host`, `Nix Package`, `Overlay`, `Sub-flake`, `Neovim Plugin`,
 ## Tooling
 
 okf is bun/TypeScript living in its own repository —
-[kriswill/okflight](https://github.com/kriswill/okflight), private for now,
-fetched over git+ssh (auth rides the SSH agent; here, 1Password) — consumed here as
+[kriswill/okflight](https://github.com/kriswill/okflight), public since
+2026-07 (plain `github:` input, no SSH auth) — consumed here as
 the `okf` flake input, re-exported as `packages.<system>.okf`, and advanced
 with `nix flake update okf`
 ([okflight-extraction](decisions/okflight-extraction.md)). This repo's

--- a/knowledge/packages/okf.md
+++ b/knowledge/packages/okf.md
@@ -8,10 +8,10 @@ timestamp: '2026-07-05T00:00:00-07:00'
 
 okf — CLI for maintaining OKF knowledge bundles (scaffold/index/validate/viz).
 
-Lives in its own **private** repository,
+Lives in its own **public** repository,
 [kriswill/okflight](https://github.com/kriswill/okflight), consumed as the
-`okf` flake input (`git+ssh://` — the fetch authenticates through the SSH
-agent, here 1Password with per-use enclave gating; no token at rest) and
+`okf` flake input (a plain `github:` fetch — public since 2026-07; the old
+git+ssh/1Password auth story is historical) and
 re-exported as `packages.<system>.okf`
 ([packages](../modules/packages.md)); advance the pin with
 `nix flake update okf`. History: `scripts/okf/` → `flakes/okf/`


### PR DESCRIPTION
Two input moves left stale current-state claims behind; this sweeps them.

**Codeberg (snowglobe-lib → `github:kriswill/snowglobe-lib` fork, `16207cf`):**
- ci.yml: drop the "Fetch flake inputs (retried)" step — its reason to exist (Codeberg 503s) is gone; every input is GitHub or FlakeHub now.
- AGENTS.md + README.md: snowglobe-lib links point at the fork.
- ci-github-actions decision record: mitigation marked resolved, dated.

**okflight (public since 2026-07, plain `github:` input):**
- okf-profile + okf package doc: no longer describe the private git+ssh/1Password fetch as current.
- okflight-extraction decision record: dated status note; the historical Decision body stays as written.

Left alone on purpose: cbissue/cbissues (Codeberg tooling), noctalia's Codeberg mirror mention, append-only log entries, and flake.nix/ci.yml comments that reference git+ssh as history or fallback.

`okf validate`: 171 files, 0 errors, 0 warnings.