### PR TITLE
ci: gate the host-closure builds — paths filter + main-push tree check

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,13 +19,44 @@
 # No hyprland.cachix.org substituter: hyprland/noctalia follow this flake's
 # nixpkgs, so their upstream caches can never hit — nebula rebuilds them from
 # source on bumps by design (the cost of the `follows` decision).
+#
+# Two layers of gating keep the (long) builds from running needlessly:
+#  * `paths:` filters both triggers to the files that can actually change the
+#    closures. Everything else — docs/, knowledge/, home/, config/, scripts/,
+#    README — is invisible to the build: home/ is stowed from the live
+#    checkout at activation, config/ snapshots are restored at runtime by the
+#    *-config CLIs, and nothing embeds those trees at eval time. A NEW
+#    build-relevant top-level dir must be added to BOTH lists.
+#  * The `gate` job skips the main-push builds when they'd be pure reruns:
+#    drv hashes depend only on tree contents, so a merge commit whose tree
+#    equals the merged PR head's tree (main didn't move since branch-off) was
+#    already built AND pushed to the cache by that PR's CI. Direct pushes,
+#    divergent merges, and squashes (no second parent to compare) still build.
 name: ci
 
 on:
   pull_request:
+    paths:
+      - flake.nix
+      - flake.lock
+      - "modules/**"
+      - "pkgs/**"
+      - "overlays/**"
+      - "lib/**"
+      - "flakes/**"
+      - ".github/workflows/ci.yml"
   push:
     branches:
       - main
+    paths:
+      - flake.nix
+      - flake.lock
+      - "modules/**"
+      - "pkgs/**"
+      - "overlays/**"
+      - "lib/**"
+      - "flakes/**"
+      - ".github/workflows/ci.yml"
   workflow_dispatch:
 
 permissions:
@@ -37,7 +68,32 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
+  # Decides whether the builds run (see the gating comment up top). Runs on
+  # every trigger; only a main-push merge commit with an unchanged tree says no.
+  gate:
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    outputs:
+      build: ${{ steps.decide.outputs.build }}
+    steps:
+      - uses: actions/checkout@v7
+        with:
+          fetch-depth: 2 # depth 2 reaches both parents of a merge commit
+
+      - id: decide
+        run: |
+          if [ "${{ github.event_name }}" = "push" ] &&
+             git rev-parse -q --verify 'HEAD^2' >/dev/null &&
+             [ "$(git rev-parse 'HEAD^{tree}')" = "$(git rev-parse 'HEAD^2^{tree}')" ]; then
+            echo "tree identical to the merged PR head — its CI run already built and cached these closures"
+            echo "build=false" >> "$GITHUB_OUTPUT"
+          else
+            echo "build=true" >> "$GITHUB_OUTPUT"
+          fi
+
   darwin-k:
+    needs: gate
+    if: needs.gate.outputs.build == 'true'
     runs-on: macos-latest # arm64 == aarch64-darwin, matches host k
     timeout-minutes: 120
     steps:
@@ -53,6 +109,8 @@ jobs:
         run: nix build .#darwinConfigurations.k.system -L
 
   nixos-nebula:
+    needs: gate
+    if: needs.gate.outputs.build == 'true'
     runs-on: ubuntu-latest
     timeout-minutes: 180
     steps:

--- a/knowledge/decisions/ci-github-actions.md
+++ b/knowledge/decisions/ci-github-actions.md
@@ -1,7 +1,7 @@
 ---
 type: Decision
 title: CI Builds Both Host Closures — No Signing Key, No Age Key, Ever
-description: 'GitHub Actions builds darwinConfigurations.k.system (free arm64 macOS runner, public repo) and nebula''s NixOS toplevel on every PR, pushing both closures to the private FlakeHub Cache via OIDC, plus a weekly update-flake-lock PR via a fine-grained PAT. The load-bearing security property: builds never decrypt sops secrets and every flake input is a public fetch (okf went public 2026-07), so CI holds zero build credentials — the Developer ID signing key never touches GitHub, and the cache needs no key at all.'
+description: 'GitHub Actions builds darwinConfigurations.k.system (free arm64 macOS runner, public repo) and nebula''s NixOS toplevel on build-relevant PRs, pushing both closures to the private FlakeHub Cache via OIDC, plus a weekly update-flake-lock PR via a fine-grained PAT. Doubly gated since 2026-07-11: a paths filter skips changes that cannot alter the closures, and a tree-equality gate skips main-push builds whose tree the merged PR already built and cached. The load-bearing security property: builds never decrypt sops secrets and every flake input is a public fetch (okf went public 2026-07), so CI holds zero build credentials — the Developer ID signing key never touches GitHub, and the cache needs no key at all.'
 tags: [ci, security, codesigning, cache]
 timestamp: '2026-07-10T21:30:00Z'
 ---
@@ -23,7 +23,8 @@ observation removed the entire hard part.
 
 ## Decision
 
-- **`ci.yml`** (pull_request + push to main): `darwin-k` builds
+- **`ci.yml`** (pull_request + push to main, both gated — see the double
+  gating bullet): `darwin-k` builds
   `.#darwinConfigurations.k.system` on `macos-latest` (arm64 — free and
   unlimited on public repos; the ~10× private-repo minute multiplier does
   not apply); `nixos-nebula` builds
@@ -41,6 +42,25 @@ observation removed the entire hard part.
   malicious PR, or exfiltrated secret store cannot leak what was never
   there. Fork PRs now build fine; lacking `id-token`, they only lose the
   cache push. `FLAKE_UPDATE_PAT` (bump PRs) is the sole remaining secret.
+- **Double gating (2026-07-11)** — the builds are long (darwin ~40 min
+  uncached; nebula longer), so ci.yml only runs them when they can matter:
+  - *Paths filter* on both triggers: `flake.nix`, `flake.lock`,
+    `modules/**`, `pkgs/**`, `overlays/**`, `lib/**`, `flakes/**`, and
+    ci.yml itself. Everything else (docs/, knowledge/, home/, config/,
+    scripts/, README) is invisible to the build — verified: home/ is stowed
+    from the live checkout at activation, config/ snapshots are restored at
+    runtime by the `*-config` CLIs, and no nix code embeds those trees at
+    eval time. A new build-relevant top-level dir must be added to BOTH
+    trigger lists.
+  - *Tree-equality gate* on main pushes: a cheap `gate` job (both build
+    jobs `needs` it) compares `HEAD^{tree}` to `HEAD^2^{tree}`. Drv hashes
+    depend only on tree contents, so a merge commit whose tree equals the
+    merged PR head's tree (main didn't move since branch-off — the normal
+    case, including the weekly bump PRs) was already built and pushed to
+    the cache by that PR's run; the gate skips the builds. Direct pushes,
+    divergent merges, and squashes (no `HEAD^2`) still build, and
+    `workflow_dispatch` always builds. Verified against history: merges
+    `bec82eb`/`3411cbf` would skip, plain commits build.
 - **Account-wide caching via a reusable workflow**
   (`.github/workflows/nix-build-cache.yml`, `workflow_call`): any
   kriswill/* repo gets Determinate Nix + FlakeHub cache CI with a one-job
@@ -83,6 +103,13 @@ observation removed the entire hard part.
   or drop the disk-reclaim step); the PAT's expiry (~1 year) needs a
   calendar note; `timeout-minutes` may need raising on uncached
   hyprland-bump PRs.
+- Watch (gating): the paths filter is an allow-list — a change that routes
+  new repo paths into the build (a module reading `../../config/...`, a
+  package embedding `scripts/...`) silently escapes CI until the dir is
+  added to both trigger lists. The gate assumes merge commits; switching
+  the repo to squash-merging would make every main push rebuild (correct,
+  just redundant — the squash tree equals the PR head tree but leaves no
+  `HEAD^2` to prove it).
 - The `follows` rebuild cost moves off the machines: after a merged bump
   PR, nebula's `nrs` pulls source-built Hyprland/noctalia prebuilt from
   the FlakeHub cache instead of compiling locally; same for the custom

--- a/knowledge/log.md
+++ b/knowledge/log.md
@@ -3,6 +3,17 @@
 ## 2026-07-11
 
 - **Update** — [ci-github-actions](decisions/ci-github-actions.md) /
+  `.github/workflows/ci.yml`: gated the long host-closure builds twice
+  over. Both triggers now carry a `paths:` allow-list (flake.nix,
+  flake.lock, modules/, pkgs/, overlays/, lib/, flakes/, ci.yml itself) —
+  docs/knowledge/home/config/scripts changes never alter the closures, so
+  they no longer spin runners. And a new `gate` job skips the main-push
+  builds when `HEAD^{tree}` equals `HEAD^2^{tree}`: a merge whose tree the
+  PR head already carried was built and cache-pushed by that PR's CI run,
+  so rebuilding on main is pure rerun. Direct pushes, divergent merges,
+  squashes, and `workflow_dispatch` still build.
+
+- **Update** — [ci-github-actions](decisions/ci-github-actions.md) /
   [okflight-extraction](decisions/okflight-extraction.md) / `.github/workflows/ci.yml`
   / AGENTS.md / README.md / [okf](packages/okf.md) / okf-profile: stale-claim
   sweep after two input moves. snowglobe-lib now comes from the


### PR DESCRIPTION
## What

Two layers of gating so `ci.yml`'s long builds (darwin ~40m uncached, nebula longer) only run when they can actually change something:

1. **Paths filter on both triggers** (`pull_request` + `push` to main): only `flake.nix`, `flake.lock`, `modules/**`, `pkgs/**`, `overlays/**`, `lib/**`, `flakes/**`, and `ci.yml` itself trigger builds. Verified the excluded trees can't affect the closures: `home/` is stowed from the live checkout at activation, `config/` snapshots restore at runtime via the `*-config` CLIs, and no nix code embeds `docs/`/`knowledge/`/`scripts/` at eval time.

2. **Tree-equality gate on main pushes**: a ~15s `gate` job compares `HEAD^{tree}` to `HEAD^2^{tree}`. Drv hashes depend only on tree contents, so a merge commit whose tree equals the merged PR head's tree was already built **and pushed to the FlakeHub cache** by that PR's run — rebuilding on main is a pure rerun, so the builds are skipped. Direct pushes, divergent merges, squashes (no `HEAD^2`), and `workflow_dispatch` still build.

Net effect on the weekly flow: the PAT-opened bump PR builds + caches both closures; the merge push matches trees and only runs the gate.

## Verification

- `actionlint` clean
- Gate logic tested against real history: merges `bec82eb`/`3411cbf` would skip (tree == PR head), plain commits build
- `okf validate` — 171 files, 0 errors (decision record `knowledge/decisions/ci-github-actions.md` + `knowledge/log.md` updated)

## Notes

- The commit carries `[skip ci]` so this PR itself doesn't trigger the builds; the merge push to main will exercise the new gate for real (expected: gate runs, builds skip).
- The paths filter is an allow-list — a future change that routes new repo paths into the build needs its dir added to **both** trigger lists (watch item recorded in the decision record).
- No branch protection exists on main, so path-skipped PRs (which show no `ci` check at all) can't block merges.