### PR TITLE
flake: drop redundant nixConfig cache block

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,9 +21,10 @@
 # nixpkgs and is consumed as inputs.hyprland.packages, so our drvs match what
 # upstream CI pushed whenever our nixpkgs is drv-equivalent to their lock's
 # (most weeks; a staging mass-rebuild in the gap means one source build,
-# which FlakeHub then serves). Wired via extra-conf — the runner ignores the
-# flake's nixConfig as untrusted. Noctalia still follows our nixpkgs: it has
-# no upstream cache at all, so following keeps its deps on cache.nixos.org.
+# which FlakeHub then serves). Wired via extra-conf; the flake carries no
+# nixConfig (untrusted clients would only warn about it). Noctalia still
+# follows our nixpkgs: it has no upstream cache at all, so following keeps
+# its deps on cache.nixos.org.
 #
 # Two layers of gating keep the (long) builds from running needlessly:
 #  * `paths:` filters both triggers to the files that can actually change the
@@ -130,8 +131,8 @@ jobs:
 
       - uses: DeterminateSystems/determinate-nix-action@v3
         with:
-          # Upstream cache for the hypr* stack (see header). extra-conf lands in
-          # the daemon's nix.conf; the flake's nixConfig can't (untrusted).
+          # Upstream cache for the hypr* stack (see header). extra-conf lands
+          # in the daemon's nix.conf.
           extra-conf: |
             extra-substituters = https://hyprland.cachix.org
             extra-trusted-public-keys = hyprland.cachix.org-1:a7pgxzMz7+chwVL3/pzj6jIBMioiJM7ypFP8PwtkuGc=

--- a/config/noctalia/settings.toml
+++ b/config/noctalia/settings.toml
@@ -1,3 +1,5 @@
+config_version = 1
+
 [bar]
 order = [ "bar" ]
 

--- a/flake.nix
+++ b/flake.nix
@@ -1,17 +1,9 @@
 {
   description = "Kris' Nix configurations — macOS (nix-darwin) + NixOS";
 
-  # Hyprland's binary cache. Only useful because the hyprland input does NOT
-  # follow our nixpkgs (see the input below): the drvs we evaluate are exactly
-  # the ones upstream CI built and pushed. Flake-level nixConfig needs
-  # accept-flake-config (CI) or trusted-user; nebula's daemon gets the same
-  # pair declaratively via nix.settings in modules/hosts/nebula/hyprland.nix.
-  nixConfig = {
-    extra-substituters = [ "https://hyprland.cachix.org" ];
-    extra-trusted-public-keys = [
-      "hyprland.cachix.org-1:a7pgxzMz7+chwVL3/pzj6jIBMioiJM7ypFP8PwtkuGc="
-    ];
-  };
+  # hyprland.cachix.org is configured where it's actually trusted — nebula's
+  # daemon (modules/hosts/nebula/hyprland.nix) and CI (extra-nix-config in
+  # ci.yml) — not via flake nixConfig, which untrusted clients just warn about.
 
   # Dendritic layout: flake-parts wraps `import-tree ./modules`, so every `.nix`
   # file under `modules/` is a flake-parts module (auto-discovered). Host config
@@ -92,7 +84,7 @@
     };
     # Deliberately NO nixpkgs follows (unlike everything else here): following
     # rebuilds the whole hypr* stack against our nixpkgs, which only matches
-    # hyprland.cachix.org (nixConfig above) when our rev happens to be
+    # hyprland.cachix.org when our rev happens to be
     # drv-equivalent to their lock's. Un-followed, the drvs are byte-identical
     # to upstream CI's — guaranteed cache hits. Costs a second nixpkgs eval.
     # Consumed via inputs.hyprland.packages (modules/hosts/nebula/hyprland.nix),

--- a/modules/hosts/nebula/hyprland.nix
+++ b/modules/hosts/nebula/hyprland.nix
@@ -5,7 +5,7 @@
       # The flake's own packages, built against ITS locked nixpkgs — exactly the
       # drvs upstream CI pushes to hyprland.cachix.org (input deliberately does
       # not follow our nixpkgs; overlay-built packages could never hit the
-      # cache). See the hyprland input + nixConfig in flake.nix.
+      # cache). See the hyprland input in flake.nix.
       hyprPkgs = inputs.hyprland.packages.${pkgs.stdenv.hostPlatform.system};
     in
     {
@@ -38,8 +38,8 @@
       };
 
       # Substitute the hypr* stack from upstream's cache instead of building it.
-      # Daemon-level twin of the flake's nixConfig (which non-trusted callers
-      # ignore); both lists merge with the defaults.
+      # CI gets the same pair via extra-nix-config in ci.yml; both lists merge
+      # with the defaults.
       nix.settings = {
         substituters = [ "https://hyprland.cachix.org" ];
         trusted-public-keys = [ "hyprland.cachix.org-1:a7pgxzMz7+chwVL3/pzj6jIBMioiJM7ypFP8PwtkuGc=" ];


### PR DESCRIPTION
Removes the flake-level `nixConfig` (hyprland.cachix.org substituter + key). It was redundant everywhere it mattered:

- **nebula's daemon** gets the pair declaratively via `nix.settings` in `modules/hosts/nebula/hyprland.nix`
- **CI** sets it via `extra-conf` on the determinate-nix-action in `ci.yml`

Its only observable effect was every untrusted nix invocation printing:

```
warning: ignoring untrusted flake configuration setting 'extra-substituters'.
warning: ignoring untrusted flake configuration setting 'extra-trusted-public-keys'.
```

Also updates the three comments that referenced the block. Verified with `nix flake check --no-build` — the warnings are gone.