### PR TITLE
darwin: give GUI apps the nix PATH

### DIFF
--- a/home/zsh/.zshrc
+++ b/home/zsh/.zshrc
@@ -1,0 +1,10 @@
+# NOT read by zsh: ZDOTDIR=$HOME/.config/zsh is exported in /etc/zshenv on
+# both OSes (modules/{darwin,nixos}/zsh.nix), so the real rc is
+# ~/.config/zsh/.zshrc and zsh never opens this file.
+#
+# It exists for GUI apps that can't see the nix PATH: macOS launchd gives
+# Dock/Finder-launched apps the bare /usr/bin:/bin:/usr/sbin:/sbin, and the
+# common workaround (Claude Code desktop, editors) is to read ~/.zshrc and
+# extract PATH from it — a probe that knows nothing of ZDOTDIR. Give those
+# probes the nix directories. Keep this file limited to PATH.
+export PATH="$HOME/.nix-profile/bin:/etc/profiles/per-user/$USER/bin:/run/current-system/sw/bin:/nix/var/nix/profiles/default/bin:$PATH"

--- a/knowledge/log.md
+++ b/knowledge/log.md
@@ -15,6 +15,18 @@
   recomputing git status (~130-150ms) — was left alone as a UX tradeoff, not
   a bug; full breakdown in the manual.
 
+- **Creation** — [gui-path](modules/gui-path.md): GUI apps get the nix PATH.
+  Two-pronged: `launchd.user.envVariables.PATH` (user-domain `launchctl
+  setenv` at activation — Dock/Finder-launched apps otherwise inherit the
+  bare `/usr/bin:/bin:/usr/sbin:/sbin`) plus a `home/zsh/.zshrc` shim for
+  apps that parse `~/.zshrc` to recover PATH instead of trusting their
+  environment (Claude Code desktop's documented probe). The shim is inert
+  for real shells: [zsh](modules/zsh.md)'s ZDOTDIR points zsh at
+  `~/.config/zsh/.zshrc` on both OSes, which is precisely why the probe
+  found nothing before. Trigger: Claude Code desktop's CI monitoring
+  reporting "gh not installed" while gh (nix profile only) worked in every
+  terminal.
+
 ## 2026-07-13
 
 - **Update** — [okflight-extraction](decisions/okflight-extraction.md) /

--- a/knowledge/modules/gui-path.md
+++ b/knowledge/modules/gui-path.md
@@ -1,0 +1,44 @@
+---
+type: Darwin Module
+title: GUI Path
+description: launchd user-domain PATH injection — macOS gives Dock/Finder-launched apps a bare PATH, so this module publishes the nix profile bins to every GUI app at activation (making gh visible to Claude Code desktop's CI monitoring, git to editors).
+resource: modules/darwin/gui-path.nix
+tags: [darwin-module, launchd, path]
+timestamp: '2026-07-17T02:08:13+00:00'
+---
+
+macOS launchd starts GUI apps with `/usr/bin:/bin:/usr/sbin:/sbin` — the
+login-shell PATH (assembled from `/etc/zshenv`'s nix hooks) never reaches
+them, so tools living only in nix profiles are invisible to anything an app
+shells out to. First symptom here: Claude Code desktop's CI monitoring
+reporting "gh not installed" while `gh` worked in every terminal.
+
+`launchd.user.envVariables.PATH` applies `launchctl setenv` in the user
+domain at activation: all *subsequently launched* GUI apps inherit the nix
+directories (`~/.nix-profile/bin`, `/etc/profiles/per-user/<user>/bin`,
+`/run/current-system/sw/bin`, `/nix/var/nix/profiles/default/bin`) ahead of
+the system defaults. Already-running apps must be relaunched; the username
+comes from `system.primaryUser`, not a hardcoded home.
+
+Two-pronged with a stow-tree companion: some apps ignore their inherited
+environment and instead parse `~/.zshrc` to recover PATH (Claude Code
+desktop does this when Dock-launched). Because the [zsh](zsh.md) module
+moves the real rc to `~/.config/zsh/.zshrc` via ZDOTDIR, that probe finds
+nothing — so `home/zsh/.zshrc` (deployed by the
+[stow tree](../patterns/stow-tree.md) on both OSes) exists purely as a
+PATH-export shim: zsh itself never reads it while ZDOTDIR is set, on either
+OS, so it is inert for real shells.
+
+Mounted ungated on every darwin host
+(see the [host-mounted modules pattern](../patterns/host-mounted-modules.md));
+auto-discovered via the [Dendritic module layout](../patterns/dendritic-modules.md).
+
+## Source
+
+- Module: [`modules/darwin/gui-path.nix`](../../modules/darwin/gui-path.nix)
+- Probe shim: [`home/zsh/.zshrc`](../../home/zsh/.zshrc)
+
+## Citations
+
+- [launchd.user.envVariables — MyNixOS option reference](https://mynixos.com/nix-darwin/option/launchd.user.envVariables)
+- [Claude Code desktop docs](https://code.claude.com/docs/en/desktop.md) — documents the ~/.zshrc PATH-extraction probe

--- a/knowledge/modules/index.md
+++ b/knowledge/modules/index.md
@@ -31,6 +31,7 @@ interesting ones by hand — scaffolding never overwrites an existing doc.
 * [Git](git.md) - Installs the binaries the stow-managed git config invokes by bare name (git, gh, gh-config, git-lfs, difftastic, …); the config itself — including 1Password SSH signing — is stow, not nix.
 * [Gpg](gpg.md) - gpg-agent on both OSes with enableSSHSupport deliberately false — 1Password owns SSH_AUTH_SOCK; gpg only backs `pass` and ad-hoc gpg use.
 * [Gtk Dark](gtk-dark.md) - Installs the adw-gtk3 theme so the portal-broadcast gtk-theme=adw-gtk3-dark resolves — dark GTK3 apps without the GTK_THEME env var that breaks libadwaita styling.
+* [GUI Path](gui-path.md) - launchd user-domain PATH injection — macOS gives Dock/Finder-launched apps a bare PATH, so this module publishes the nix profile bins to every GUI app at activation (making gh visible to Claude Code desktop's CI monitoring, git to editors).
 * [Hardware Configuration](hardware-configuration.md) - nixos-generate-config output in the two-line dendritic wrapper: initrd kernel modules, kvm-amd, x86_64-linux hostPlatform, and AMD microcode updates.
 * [Helium Chrome Shim](helium-chrome-shim.md) - Plants an exec-wrapper at the canonical Google Chrome.app binary path on every rebuild, so Chrome-only tooling (chrome-devtools-mcp / Puppeteer channel 'stable') launches Helium — no per-tool --executablePath wiring.
 * [Helium](helium.md) - Helium browser — enables the upstream programs.helium module and declares a root-owned Chromium managed policy in /etc (privacy baseline, DuckDuckGo, force-installed extensions).

--- a/knowledge/modules/zsh.md
+++ b/knowledge/modules/zsh.md
@@ -27,6 +27,10 @@ newer than the cache. See
 [shell-startup-performance manual](../../docs/shell-startup-performance.md)
 for the profiling that motivated it.
 
+Side effect of ZDOTDIR worth knowing: `~/.zshrc` is never read by zsh, so
+the stow tree ships one anyway as a PATH shim for GUI apps that parse it —
+see [GUI Path](gui-path.md).
+
 ## Twin differences
 
 Darwin additionally sets `enableAutosuggestions`/`enableSyntaxHighlighting`

--- a/modules/darwin/gui-path.nix
+++ b/modules/darwin/gui-path.nix
@@ -1,0 +1,25 @@
+# Give GUI apps the nix PATH. launchd starts Dock/Finder-launched apps with
+# the bare /usr/bin:/bin:/usr/sbin:/sbin, so anything they shell out to (gh
+# for Claude Code desktop's CI monitoring, git for editors) is invisible when
+# it lives only in a nix profile. Setting the user-domain launchd PATH at
+# activation fixes every GUI app at once; apps must be relaunched to see it.
+# Companion shim: home/zsh/.zshrc feeds the same PATH to apps that probe
+# ~/.zshrc instead of trusting their inherited environment.
+{
+  flake.modules.darwin.gui-path =
+    { config, ... }:
+    {
+      # A list value is joined with colons by the option itself.
+      launchd.user.envVariables.PATH = [
+        "/Users/${config.system.primaryUser}/.nix-profile/bin"
+        "/etc/profiles/per-user/${config.system.primaryUser}/bin"
+        "/run/current-system/sw/bin"
+        "/nix/var/nix/profiles/default/bin"
+        "/usr/local/bin"
+        "/usr/bin"
+        "/bin"
+        "/usr/sbin"
+        "/sbin"
+      ];
+    };
+}


### PR DESCRIPTION
## What changed

Two complementary fixes for GUI apps not seeing nix-profile tools (trigger: Claude Code desktop's CI monitoring said "gh not installed" while `gh` worked in every terminal — it lives only in `/run/current-system/sw/bin`):

- **`modules/darwin/gui-path.nix`** (new universal darwin module): `launchd.user.envVariables.PATH` puts the nix profile bins ahead of the system defaults for every subsequently launched GUI app (user-domain `launchctl setenv` at activation). Username comes from `system.primaryUser`; the option colon-joins list values natively.
- **`home/zsh/.zshrc`** (new stow file, deployed on both OSes): a PATH-export shim for apps that don't trust their inherited environment and instead parse `~/.zshrc` — Claude Code desktop's documented probe when Dock-launched. ZDOTDIR (exported from `/etc/zshenv` on both OSes) means zsh itself never reads `~/.zshrc`, which is both why the probe found nothing before and why this shim is inert for real shells.

Knowledge bundle: new [gui-path module doc](knowledge/modules/gui-path.md) (MyNixOS option citation verified to resolve), ZDOTDIR cross-link added to the zsh doc, log entry; `okf validate` clean (173 files, 0 errors).

## Why two prongs

The launchd env fixes every GUI app that uses its inherited PATH; the shim covers the apps that deliberately re-derive PATH from `~/.zshrc`. Claude Code desktop is in the second camp, so it needs the shim; other apps (editors shelling out to git, etc.) benefit from the first.

## Reviewer notes

- The launchd value takes effect per-app-launch after `nrs` activation (already applied imperatively on `k` via `launchctl setenv` for immediate effect — lasts until logout, the module makes it stick).
- The shim is a no-op on nebula too (nixos zsh module sets the same ZDOTDIR), so it's safe cross-platform; it's not skip-listed.
- Verified: host `k` closure builds; `launchd.user.envVariables.PATH` eval matches the intended colon-joined value; `~/.zshrc` stows correctly.